### PR TITLE
Ignore keyed histograms with an excessive number of labels.

### DIFF
--- a/mozaggregator/aggregator.py
+++ b/mozaggregator/aggregator.py
@@ -85,6 +85,10 @@ def _extract_histograms(state, payload, is_child=False):
         return
 
     for name, histograms in keyed_histograms.iteritems():
+        # See Bug 1275010 and 1275019
+        if name in ["MESSAGE_MANAGER_MESSAGE_SIZE",
+                    "VIDEO_DETAILED_DROPPED_FRAMES_PROPORTION"]:
+            continue
         _extract_keyed_histograms(state, name, histograms, is_child)
 
 

--- a/tests/dataset.py
+++ b/tests/dataset.py
@@ -1,5 +1,7 @@
 import uuid
 
+from itertools import product, repeat
+
 NUM_CHILDREN_PER_PING = 3
 NUM_PINGS_PER_DIMENSIONS = 2
 SCALAR_VALUE = 42
@@ -88,26 +90,9 @@ simple_measurements_template = {"uptime": SCALAR_VALUE, "addonManager": {u'XPIDB
 
 
 def generate_pings():
-    for submission_date in ping_dimensions["submission_date"]:
-        for channel in ping_dimensions["channel"]:
-            for version in ping_dimensions["version"]:
-                for build_id in ping_dimensions["build_id"]:
-                    for application in ping_dimensions["application"]:
-                        for arch in ping_dimensions["arch"]:
-                            for os in ping_dimensions["os"]:
-                                for os_version in ping_dimensions["os_version"]:
-                                    for e10s in ping_dimensions["e10s"]:
-                                        for i in range(NUM_PINGS_PER_DIMENSIONS):
-                                            dimensions = {u"submission_date": submission_date,
-                                                            u"channel": channel,
-                                                            u"version": version,
-                                                            u"build_id": build_id,
-                                                            u"application": application,
-                                                            u"arch": arch,
-                                                            u"os": os,
-                                                            u"os_version": os_version,
-                                                            u"e10s": e10s}
-                                            yield generate_payload(dimensions)
+    for dimensions in [dict(x) for x in product(*[zip(repeat(k), v) for k, v in ping_dimensions.iteritems()])]:
+        for i in range(NUM_PINGS_PER_DIMENSIONS):
+            yield generate_payload(dimensions)
 
 
 def generate_payload(dimensions):

--- a/tests/dataset.py
+++ b/tests/dataset.py
@@ -86,6 +86,19 @@ keyed_histograms_template = {u'BLOCKED_ON_PLUGIN_INSTANCE_DESTROY_MS':
                                                                          u'785': 1,
                                                                          u'8': 8}}}}
 
+ignored_keyed_histograms_template = {u'MESSAGE_MANAGER_MESSAGE_SIZE':
+                                     {u'foo': {u'bucket_count': 20,
+                                               u'histogram_type': 0,
+                                               u'sum': 0,
+                                               u'values': {u'0': 0}
+                                     }},
+                                     "VIDEO_DETAILED_DROPPED_FRAMES_PROPORTION":
+                                     {u'foo': {u'bucket_count': 20,
+                                               u'histogram_type': 0,
+                                               u'sum': 0,
+                                               u'values': {u'0': 0}
+                                     }}}
+
 simple_measurements_template = {"uptime": SCALAR_VALUE, "addonManager": {u'XPIDB_parseDB_MS': SCALAR_VALUE}}
 
 
@@ -111,7 +124,8 @@ def generate_payload(dimensions):
 
     payload = {u"simpleMeasurements": simple_measurements_template,
                u"histograms": histograms_template,
-               u"keyedHistograms": keyed_histograms_template,
+               u"keyedHistograms": dict(keyed_histograms_template.items() +
+                                        ignored_keyed_histograms_template.items()),
                u"childPayloads": child_payloads}
     environment = {u"system": {u"os": {u"name": dimensions["os"],
                                        u"version": dimensions["os_version"]}},

--- a/tests/test_aggregator.py
+++ b/tests/test_aggregator.py
@@ -171,6 +171,8 @@ def test_keyed_histograms():
                 assert(set(histogram_template.keys()) == set(value["histogram"].keys()))
                 assert((pd.Series(histogram_template)*value["count"] == pd.Series(value["histogram"])).all())
 
+            assert(metric not in ignored_keyed_histograms_template.keys())
+
     assert(len(metric_count) == len(keyed_histograms_template))  # Assume one label per keyed histogram
     for v in metric_count.values():
         assert(v == 2*len(build_id_aggregates))  # Count both child and parent metrics


### PR DESCRIPTION
See [Bug 1275010](https://bugzilla.mozilla.org/show_bug.cgi?id=1275010) and [Bug 1275019](https://bugzilla.mozilla.org/show_bug.cgi?id=1275019).