### PR TITLE
Bug 1286951 - Update mozaggregator to account for change in childPayloads

### DIFF
--- a/mozaggregator/aggregator.py
+++ b/mozaggregator/aggregator.py
@@ -231,6 +231,7 @@ def _aggregate_ping(state, ping):
     _extract_histograms(state, ping.get("payload", {}))
     _extract_simple_measures(state, ping.get("payload", {}).get("simpleMeasurements", {}))
     _extract_child_payloads(state, ping.get("payload", {}).get("childPayloads", {}))
+    _extract_histograms(state, ping.get("payload", {}).get("processes", {}).get("content", {}), True)
     return state
 
 
@@ -250,7 +251,7 @@ def _aggregate_aggregates(agg1, agg2):
 
 
 def _trim_payload(payload):
-    return {k: v for k, v in payload.iteritems() if k in ["histograms", "keyedHistograms", "simpleMeasurements"]}
+    return {k: v for k, v in payload.iteritems() if k in ["histograms", "keyedHistograms", "simpleMeasurements", "processes"]}
 
 
 def _map_ping_to_dimensions(ping):

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@
 from setuptools import setup
 
 setup(name='python_mozaggregator',
-    version='0.2.5.5',
+    version='0.2.5.6',
     author='Roberto Agostino Vitillo',
     author_email='rvitillo@mozilla.com',
     description='Telemetry aggregation job',

--- a/tests/test_aggregator.py
+++ b/tests/test_aggregator.py
@@ -73,6 +73,8 @@ def test_simple_measurements():
             if metric.startswith("SIMPLE_MEASURES_"):
                 metric_count[metric] += 1
                 assert(label == "")
+                # Simple measurements are still in childPayloads.
+                # expected_count() is correct only for child dimensions in processes.content.
                 assert(value["count"] == NUM_PINGS_PER_DIMENSIONS*(NUM_CHILDREN_PER_PING if child else 1))
                 assert(value["sum"] == value["count"]*SCALAR_VALUE)
                 assert(value["histogram"][str(SIMPLE_SCALAR_BUCKET)] == value["count"])
@@ -94,7 +96,7 @@ def test_classic_histograms():
             if histogram:
                 metric_count[metric] += 1
                 assert(label == "")
-                assert(value["count"] == NUM_PINGS_PER_DIMENSIONS*(NUM_CHILDREN_PER_PING if child else 1))
+                assert(value["count"] == expected_count(child))
                 assert(value["sum"] == value["count"]*histogram["sum"])
                 assert(set(histogram["values"].keys()) == set(value["histogram"].keys()))
                 assert((pd.Series(histogram["values"])*value["count"] == pd.Series(value["histogram"])).all())
@@ -116,7 +118,7 @@ def test_count_histograms():
             if histogram:
                 metric_count[metric] += 1
                 assert(label == "")
-                assert(value["count"] == NUM_PINGS_PER_DIMENSIONS*(NUM_CHILDREN_PER_PING if child else 1))
+                assert(value["count"] == expected_count(child))
                 assert(value["sum"] == value["count"]*histogram["sum"])
                 assert(value["histogram"][str(COUNT_SCALAR_BUCKET)] == value["count"])
 
@@ -140,7 +142,7 @@ def test_use_counter2_histogram():
             if histogram:
                 metric_count[metric] += 1
                 assert(label == "")
-                assert(value["count"] == NUM_PINGS_PER_DIMENSIONS*(NUM_CHILDREN_PER_PING if child else 1))
+                assert(value["count"] == expected_count(child))
                 assert(value["sum"] == value["count"]*histogram["sum"])
 
                 if metric.endswith("_DOCUMENT"):
@@ -164,7 +166,7 @@ def test_keyed_histograms():
             if metric in keyed_histograms_template.keys():
                 metric_count["{}_{}".format(metric, label)] += 1
                 assert(label != "")
-                assert(value["count"] == NUM_PINGS_PER_DIMENSIONS*(NUM_CHILDREN_PER_PING if child else 1))
+                assert(value["count"] == expected_count(child))
                 assert(value["sum"] == value["count"]*keyed_histograms_template[metric][label]["sum"])
 
                 histogram_template = keyed_histograms_template[metric][label]["values"]


### PR DESCRIPTION
When bug 1218576 lands, Firefox will start sending child histograms in
.processes.child.{keyedH|h}istograms
instead of
.childPayloads[i].{keyedH|h}istograms

Handle pings that have child histograms in either (or a mix of both) config.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/python_mozaggregator/17)
<!-- Reviewable:end -->
