### PR TITLE
Bug 	1297060 - Add support for categorical histograms

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@
 from setuptools import setup
 
 setup(name='python_mozaggregator',
-    version='0.2.5.6',
+    version='0.2.5.7',
     author='Roberto Agostino Vitillo',
     author_email='rvitillo@mozilla.com',
     description='Telemetry aggregation job',

--- a/tests/dataset.py
+++ b/tests/dataset.py
@@ -64,7 +64,12 @@ histograms_template = {u"EVENTLOOP_UI_ACTIVITY_EXP_MS": {u'bucket_count': 20,
                                                                u'histogram_type': 2,
                                                                u'range': [1, 2],
                                                                u'sum': 1,
-                                                               u'values': {u'0': 0, u'1': 1}}}
+                                                               u'values': {u'0': 0, u'1': 1}},
+                       u"TELEMETRY_TEST_CATEGORICAL": {u'bucket_count': 4,
+                                                       u'histogram_type': 5,
+                                                       u'range': [1, 2],
+                                                       u'sum': 3,
+                                                       u'values': {u'0': 1, u'1': 1, u'2':1, u'3':0}}}
 
 keyed_histograms_template = {u'BLOCKED_ON_PLUGIN_INSTANCE_DESTROY_MS':
                              {u'Shockwave Flash17.0.0.188': {u'bucket_count': 20,

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -187,7 +187,8 @@ def test_histogram(prefix, channel, version, dates, metric, value, expected_coun
             assert((current == expected).all())
             assert(res["sum"] == value["sum"]*res["count"])
         else:
-            current = pd.Series(res["histogram"], index=map(int, reply["buckets"]))
+            ind_type = int if value["histogram_type"] != 5 else str #categorical histograms
+            current = pd.Series(res["histogram"], index=map(ind_type, reply["buckets"]))
             expected = Histogram(metric, value).get_value()*res["count"]
 
             assert((current == expected).all())


### PR DESCRIPTION
Luckily, this was basically already supported. These tests show how to take the result and use it to recreate the categorical histogram with correct labels.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/python_mozaggregator/19)
<!-- Reviewable:end -->
