### PR TITLE
Bug 1286868 - Use main pings instead of saved_session

### DIFF
--- a/mozaggregator/aggregator.py
+++ b/mozaggregator/aggregator.py
@@ -27,15 +27,22 @@ def aggregate_metrics(sc, channels, submission_date, fraction=1):
     if not isinstance(channels, (tuple, list)):
         channels = [channels]
 
+
+    def telemetry_enabled(ping):
+        return ping.get('environment', {}) \
+                   .get('settings', {}) \
+                   .get('telemetryEnabled', False)
+
     channels = set(channels)
     pings = Dataset.from_source('telemetry') \
                   .where(appUpdateChannel=lambda x : x in channels, 
                          submissionDate=submission_date,
-                         docType="saved_session",
+                         docType="main",
                          sourceVersion='4') \
-                  .records(sc, sample=fraction)
-    return _aggregate_metrics(pings)
+                  .records(sc, sample=fraction) \
+                  .filter(telemetry_enabled)
 
+    return _aggregate_metrics(pings)
 
 def _aggregate_metrics(pings):
     # Use few reducers only when running the test-suite to speed execution up.

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@
 from setuptools import setup
 
 setup(name='python_mozaggregator',
-    version='0.2.5.8',
+    version='0.2.5.9',
     author='Roberto Agostino Vitillo',
     author_email='rvitillo@mozilla.com',
     description='Telemetry aggregation job',


### PR DESCRIPTION
Saved_session pings are being deprecated.
However, main pings are both opt-in and opt-out, while saved_session
were just opt-in. For this reason we are filtering to include only
opt-in users, so the results should be similar.

Note that results will not be identical, since saved_session pings
often lag main pings, due to the main ping submission on date split.

For information about how this was tested and how long it took, see the associated bug.
@vitillo r?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/python_mozaggregator/21)
<!-- Reviewable:end -->
