### PR TITLE
Bug 1286868 - Use main pings instead of saved_session

### DIFF
--- a/mozaggregator/aggregator.py
+++ b/mozaggregator/aggregator.py
@@ -27,15 +27,25 @@ def aggregate_metrics(sc, channels, submission_date, fraction=1):
     if not isinstance(channels, (tuple, list)):
         channels = [channels]
 
+
+    def telemetry_enabled(ping):
+        try:
+            return ping.get('environment', {}) \
+                       .get('settings', {}) \
+                       .get('telemetryEnabled', False)
+        except Exception:
+            return False
+
     channels = set(channels)
     pings = Dataset.from_source('telemetry') \
                   .where(appUpdateChannel=lambda x : x in channels, 
                          submissionDate=submission_date,
-                         docType="saved_session",
+                         docType="main",
                          sourceVersion='4') \
-                  .records(sc, sample=fraction)
-    return _aggregate_metrics(pings)
+                  .records(sc, sample=fraction) \
+                  .filter(telemetry_enabled)
 
+    return _aggregate_metrics(pings)
 
 def _aggregate_metrics(pings):
     # Use few reducers only when running the test-suite to speed execution up.

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@
 from setuptools import setup
 
 setup(name='python_mozaggregator',
-    version='0.2.5.12',
+    version='0.2.5.13',
     author='Roberto Agostino Vitillo',
     author_email='rvitillo@mozilla.com',
     description='Telemetry aggregation job',


### PR DESCRIPTION
We had some issues previously where telemetry_enabled was raising an exception, which has been fixed. Additionally, we've increased the number of nodes and the timeout for the job.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/python_mozaggregator/25)
<!-- Reviewable:end -->
