### PR TITLE
Ignore categorical histograms before 20170117

### DIFF
--- a/mozaggregator/service.py
+++ b/mozaggregator/service.py
@@ -18,6 +18,7 @@ from aggregator import SIMPLE_MEASURES_LABELS, COUNT_HISTOGRAM_LABELS, NUMERIC_S
 from db import get_db_connection_string, histogram_revision_map
 from scalar import Scalar
 from logging.handlers import SysLogHandler
+from datetime import datetime
 
 pool = None
 app = Flask(__name__)
@@ -158,6 +159,17 @@ def _get_description(channel, prefix, metric):
     return Scalar(metric, 0, channel=channel).get_definition().get('description', '')
 
 
+def filter_missing_data(kind, data):
+    """categorical data from before 2017-01-17 is all 0's,
+    so ignore it.
+    """
+    if kind != 'categorical':
+        return data
+
+    min_date = datetime.strptime('20170117', '%Y%m%d')
+    return [d for d in data if datetime.strptime(d['date'], '%Y%m%d') >= min_date]
+
+
 @app.route('/aggregates_by/<prefix>/channels/<channel>/', methods=["GET"])
 @cache_request
 def get_dates_metrics(prefix, channel):
@@ -215,6 +227,7 @@ def get_dates_metrics(prefix, channel):
         count = row[2][-1]
         pretty_result["data"].append({"date": date, "label": label, "histogram": histogram, "count": count, "sum": sum})
 
+    pretty_result["data"] = filter_missing_data(kind, pretty_result["data"])
     return Response(json.dumps(pretty_result), mimetype="application/json")
 
 

--- a/tests/dataset.py
+++ b/tests/dataset.py
@@ -11,10 +11,10 @@ SIMPLE_SCALAR_BUCKET = 35
 COUNT_SCALAR_BUCKET = 40
 NUMERIC_SCALAR_BUCKET = 40
 
-ping_dimensions = {"submission_date": [u"20150601", u"20150603"],
+ping_dimensions = {"submission_date": [u"20170601", u"20170603"],
                    "channel": [u"nightly", u"aurora"],
                    "version": [u"40.0a1", u"41"],
-                   "build_id": [u"20150601000000", u"20150602000000"],
+                   "build_id": [u"20170201000000", u"20170202000000"],
                    "application": [u"Firefox", u"Fennec"],
                    "arch": [u"x86", u"x86-64"],
                    "os": [u"Linux", u"Windows_NT"],


### PR DESCRIPTION
These histograms were incorrect - their data is all 0's.
See https://github.com/mozilla/python_moztelemetry/pull/102

@vitillo r?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/python_mozaggregator/27)
<!-- Reviewable:end -->
