### PR TITLE
Bug 1336119 - Aggregate Fennec saved-session pings

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@
 from setuptools import setup
 
 setup(name='python_mozaggregator',
-    version='0.2.6.1',
+    version='0.2.6.2',
     author='Roberto Agostino Vitillo',
     author_email='rvitillo@mozilla.com',
     description='Telemetry aggregation job',


### PR DESCRIPTION
I tested this on data from `20170130`. I used the `telemetry_aggregator.py` we use for airflow. I ran it on 100% of the data and saw no errors.

@vitillo r?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/python_mozaggregator/31)
<!-- Reviewable:end -->
