### PR TITLE
Bug 1339139 - Enable content/parent process types

### DIFF
--- a/mozaggregator/service.py
+++ b/mozaggregator/service.py
@@ -209,6 +209,11 @@ def get_dates_metrics(prefix, channel):
     mapping = {"true": True, "false": False}
     dimensions = {k: mapping.get(v, v) for k, v in request.args.iteritems()}
 
+    if 'child' in dimensions:
+        # Process types in the db are true/false, not content/process
+        new_process_map = {"content": True, "parent": False}
+        dimensions['child'] = new_process_map.get(dimensions['child'], dimensions['child'])
+
     # Get dates
     dates = dimensions.pop('dates', "").split(',')
     version = dimensions.pop('version', None)

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -190,6 +190,21 @@ def test_changed_child_value():
     assert reply.ok
     assert reply.json() is not None
 
+def test_using_content_types():
+    reply = requests.get("{}/aggregates_by/submission_date/channels/nightly?version=41&dates=20150603&metric=GC_MAX_PAUSE_MS&child=content".format(SERVICE_URI))
+    assert reply.ok
+    assert reply.json() is not None
+
+def test_using_parent_types():
+    reply = requests.get("{}/aggregates_by/submission_date/channels/nightly?version=41&dates=20150603&metric=GC_MAX_PAUSE_MS&child=parent".format(SERVICE_URI))
+    assert reply.ok
+    assert reply.json() is not None
+
+def test_using_gpu_types():
+    reply = requests.get("{}/aggregates_by/submission_date/channels/nightly?version=41&dates=20150603&metric=GC_MAX_PAUSE_MS&child=gpu".format(SERVICE_URI))
+    assert reply.ok
+    assert reply.json() is not None
+
 def test_new_db_functions_backwards_compatible():
     conn = _create_connection()
     cursor = conn.cursor()


### PR DESCRIPTION
In https://github.com/mozilla/python_mozaggregator/pull/29, we
added the new processes to the get_filter_options, but not to
get_metrics (so they weren't correctly transformed for querying
the database). This change transforms content => true and
parent => false for child GET params.

@chutten r?