### PR TITLE
Bug 1336000 - Add Cache Control and ETag headers

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@
 from setuptools import setup
 
 setup(name='python_mozaggregator',
-    version='0.2.6.3',
+    version='0.2.6.4',
     author='Roberto Agostino Vitillo',
     author_email='rvitillo@mozilla.com',
     description='Telemetry aggregation job',


### PR DESCRIPTION
This change implements both cache control and ETag headers.

For Cache-Control:
For all requests but submission-date aggregates, the max-age
is set until the start of the next load of the database
(we know the data won't change until then).
If the request is during a load, max-age is set to 0.

For submission-date aggregates, max-age is always set to 24h.

ETags:
Etags are not set on any requests but submission-date aggregates.
The ETags are the same for all values, since submission-date
aggregates will never change, unless we do a backfill.

Thus, the single ETag value can be updated, invalidating all
previous ETags. This should only be done after a backfill.

@vitillo r?