### PR TITLE
Ignore cloudwatch log upload failures

### DIFF
--- a/mozaggregator/service.py
+++ b/mozaggregator/service.py
@@ -163,6 +163,8 @@ def log_request():
             ]
         }
 
+        response = None
+
         for retry in xrange(MAX_RETRIES + 1):
             if sequence_token is not None:
                 kwargs['sequenceToken'] = sequence_token
@@ -177,7 +179,7 @@ def log_request():
                         logStreamNamePrefix = LOG_STREAM_NAME)
                     sequence_token = stream_describe['logStreams'][0]['uploadSequenceToken']
                 else:
-                    raise
+                    pass
 
         if response and response.get('nextSequenceToken'):
             sequence_token = response['nextSequenceToken']


### PR DESCRIPTION
Thoughts on ignoring failures? Should only happen briefly on high usage. We can also request to increase our limits which should fix this problem in the future.

Also fixes a bug where the response from cloudwatch logs is
never set.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/python_mozaggregator/46)
<!-- Reviewable:end -->
