### PR TITLE
Aggregate String Scalars like Keyed

### DIFF
--- a/mozaggregator/aggregator.py
+++ b/mozaggregator/aggregator.py
@@ -7,26 +7,9 @@
 
 import sys
 
+from constants import *
 from moztelemetry.dataset import Dataset 
-from moztelemetry.histogram import cached_exponential_buckets
 from collections import defaultdict
-
-# Simple measurement, count histogram, and numeric scalars labels & prefixes
-SIMPLE_MEASURES_LABELS = cached_exponential_buckets(1, 30000, 50)
-COUNT_HISTOGRAM_LABELS = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 21, 23, 25, 27, 29, 31, 34, 37, 40, 43, 46, 50, 54, 58, 63, 68, 74, 80, 86, 93, 101, 109, 118, 128, 138, 149, 161, 174, 188, 203, 219, 237, 256, 277, 299, 323, 349, 377, 408, 441, 477, 516, 558, 603, 652, 705, 762, 824, 891, 963, 1041, 1125, 1216, 1315, 1422, 1537, 1662, 1797, 1943, 2101, 2271, 2455, 2654, 2869, 3102, 3354, 3626, 3920, 4238, 4582, 4954, 5356, 5791, 6261, 6769, 7318, 7912, 8554, 9249, 10000]
-NUMERIC_SCALARS_LABELS = COUNT_HISTOGRAM_LABELS
-
-SIMPLE_MEASURES_PREFIX = 'SIMPLE_MEASURES'
-COUNT_HISTOGRAM_PREFIX = '[[COUNT]]'
-SCALARS_PREFIX = 'SCALARS'
-
-SCALAR_MEASURE_MAP = {
-    SIMPLE_MEASURES_PREFIX: SIMPLE_MEASURES_LABELS,
-    COUNT_HISTOGRAM_PREFIX: COUNT_HISTOGRAM_LABELS,
-    SCALARS_PREFIX: NUMERIC_SCALARS_LABELS
-}
-
-PROCESS_TYPES = {"parent", "content", "gpu"}
 
 def aggregate_metrics(sc, channels, submission_date, main_ping_fraction=1, fennec_ping_fraction=1):
     """ Returns the build-id and submission date aggregates for a given submission date.
@@ -38,7 +21,6 @@ def aggregate_metrics(sc, channels, submission_date, main_ping_fraction=1, fenne
     """
     if not isinstance(channels, (tuple, list)):
         channels = [channels]
-
 
     def telemetry_enabled(ping):
         try:
@@ -250,9 +232,9 @@ def _extract_unkeyed_scalars(state, scalar_dict, process):
             continue
 
         scalar_name = u"_".join((SCALARS_PREFIX, name.upper()))
-        if isinstance(value, str):
+        if isinstance(value, str) and name in STRING_SCALAR_WHITELIST:
             _extract_scalar_value(state, scalar_name, value, 1, NUMERIC_SCALARS_LABELS, process)
-        else:
+        elif isinstance(value, (int, float, long)):
             _extract_scalar_value(state, scalar_name, u"", value, NUMERIC_SCALARS_LABELS, process)
 
 

--- a/mozaggregator/constants.py
+++ b/mozaggregator/constants.py
@@ -1,0 +1,30 @@
+
+from moztelemetry.histogram import cached_exponential_buckets
+
+# Simple measurement, count histogram, and numeric scalars labels & prefixes
+SIMPLE_MEASURES_LABELS = cached_exponential_buckets(1, 30000, 50)
+COUNT_HISTOGRAM_LABELS = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 21, 23, 25, 27, 29, 31, 34, 37, 40, 43, 46, 50, 54, 58, 63, 68, 74, 80, 86, 93, 101, 109, 118, 128, 138, 149, 161, 174, 188, 203, 219, 237, 256, 277, 299, 323, 349, 377, 408, 441, 477, 516, 558, 603, 652, 705, 762, 824, 891, 963, 1041, 1125, 1216, 1315, 1422, 1537, 1662, 1797, 1943, 2101, 2271, 2455, 2654, 2869, 3102, 3354, 3626, 3920, 4238, 4582, 4954, 5356, 5791, 6261, 6769, 7318, 7912, 8554, 9249, 10000]
+NUMERIC_SCALARS_LABELS = COUNT_HISTOGRAM_LABELS
+
+SIMPLE_MEASURES_PREFIX = 'SIMPLE_MEASURES'
+COUNT_HISTOGRAM_PREFIX = '[[COUNT]]'
+SCALARS_PREFIX = 'SCALARS'
+
+SCALAR_MEASURE_MAP = {
+    SIMPLE_MEASURES_PREFIX: SIMPLE_MEASURES_LABELS,
+    COUNT_HISTOGRAM_PREFIX: COUNT_HISTOGRAM_LABELS,
+    SCALARS_PREFIX: NUMERIC_SCALARS_LABELS
+}
+
+PROCESS_TYPES = {"parent", "content", "gpu"}
+
+STRING_SCALAR_WHITELIST = {
+    "telemetry.test.string_kind"
+}
+
+HISTOGRAM_REVISION_MAP = {
+    "nightly": "https://hg.mozilla.org/mozilla-central/rev/tip",
+    "aurora": "https://hg.mozilla.org/releases/mozilla-aurora/rev/tip",
+    "beta": "https://hg.mozilla.org/releases/mozilla-beta/rev/tip",
+    "release": "https://hg.mozilla.org/releases/mozilla-release/rev/tip"
+}

--- a/mozaggregator/db.py
+++ b/mozaggregator/db.py
@@ -17,15 +17,7 @@ import config
 from moztelemetry.spark import Histogram
 from boto.s3.connection import S3Connection
 from cStringIO import StringIO
-from mozaggregator.aggregator import SCALAR_MEASURE_MAP
-
-# Use latest revision, we don't really care about histograms that have
-# been removed. This only works though if histogram definitions are
-# immutable, which has been the case so far.
-histogram_revision_map = {"nightly": "https://hg.mozilla.org/mozilla-central/rev/tip",
-                          "aurora": "https://hg.mozilla.org/releases/mozilla-aurora/rev/tip",
-                          "beta": "https://hg.mozilla.org/releases/mozilla-beta/rev/tip",
-                          "release": "https://hg.mozilla.org/releases/mozilla-release/rev/tip"}
+from constants import *
 
 _metric_printable = set(string.ascii_uppercase + string.ascii_lowercase + string.digits + "_-[].")
 
@@ -86,7 +78,7 @@ def _preparedb():
 
 
 def _get_complete_histogram(channel, metric, values):
-    revision = histogram_revision_map.get(channel, "nightly")  # Use nightly revision if the channel is unknown
+    revision = HISTOGRAM_REVISION_MAP.get(channel, "nightly")  # Use nightly revision if the channel is unknown
 
     for prefix, labels in SCALAR_MEASURE_MAP.iteritems():
         if metric.startswith(prefix):

--- a/mozaggregator/db.py
+++ b/mozaggregator/db.py
@@ -17,9 +17,7 @@ import config
 from moztelemetry.spark import Histogram
 from boto.s3.connection import S3Connection
 from cStringIO import StringIO
-from mozaggregator.aggregator import SIMPLE_MEASURES_LABELS, COUNT_HISTOGRAM_LABELS, NUMERIC_SCALARS_LABELS, \
-                                    SIMPLE_MEASURES_PREFIX, COUNT_HISTOGRAM_PREFIX, NUMERIC_SCALARS_PREFIX, \
-                                    SCALAR_MEASURE_MAP
+from mozaggregator.aggregator import SCALAR_MEASURE_MAP
 
 # Use latest revision, we don't really care about histograms that have
 # been removed. This only works though if histogram definitions are

--- a/mozaggregator/service.py
+++ b/mozaggregator/service.py
@@ -14,10 +14,8 @@ from functools import wraps
 from gevent.monkey import patch_all
 from psycogreen.gevent import patch_psycopg
 from psycopg2.pool import SimpleConnectionPool
-from aggregator import SIMPLE_MEASURES_LABELS, COUNT_HISTOGRAM_LABELS, NUMERIC_SCALARS_LABELS, \
-                        SIMPLE_MEASURES_PREFIX, COUNT_HISTOGRAM_PREFIX, NUMERIC_SCALARS_PREFIX, \
-                        SCALAR_MEASURE_MAP
-from db import get_db_connection_string, histogram_revision_map
+from constants import *
+from db import get_db_connection_string
 from moztelemetry.scalar import Scalar
 from logging.handlers import SysLogHandler
 from botocore.exceptions import ClientError
@@ -258,7 +256,7 @@ def get_filters_options():
 
 
 def _get_description(channel, prefix, metric):
-    if prefix != NUMERIC_SCALARS_PREFIX:
+    if prefix != SCALARS_PREFIX:
         return ''
 
     metric = metric.replace(prefix + '_', '').lower()
@@ -297,7 +295,7 @@ def get_dates_metrics(prefix, channel):
             description = _get_description(channel, _prefix, metric)
             break
     else:
-        revision = histogram_revision_map.get(channel, "nightly")  # Use nightly revision if the channel is unknown
+        revision = HISTOGRAM_REVISION_MAP.get(channel, "nightly")  # Use nightly revision if the channel is unknown
         try:
             definition = Histogram(metric, {"values": {}}, revision=revision)
         except KeyError:

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(name='python_mozaggregator',
     package_dir={'mozaggregator': 'mozaggregator'},
     install_requires=[
         'awscli',
-        'python_moztelemetry',
+        'python_moztelemetry >= 0.8.3',
         'Flask',
         'flask-cors',
         'flask-cache',

--- a/tests/dataset.py
+++ b/tests/dataset.py
@@ -12,6 +12,8 @@ SCALAR_VALUE = 42
 SIMPLE_SCALAR_BUCKET = 35
 COUNT_SCALAR_BUCKET = 40
 NUMERIC_SCALAR_BUCKET = 40
+STRING_SCALAR_VALUE = "theempiredidnothingwrong"
+STRING_SCALAR_BUCKET = "1"
 
 ping_dimensions = {"submission_date": [u"20150601", u"20150603"],
                    "channel": [u"nightly", u"aurora"],
@@ -116,15 +118,18 @@ ignored_keyed_histograms_template = {u'MESSAGE_MANAGER_MESSAGE_SIZE':
 
 simple_measurements_template = {"uptime": SCALAR_VALUE, "addonManager": {u'XPIDB_parseDB_MS': SCALAR_VALUE}}
 
-scalars_template = {
+numeric_scalars_template = {
     "browser.engagement.total_uri_count": SCALAR_VALUE,
     "browser.engagement.tab_open_event_count": SCALAR_VALUE
 }
 
+string_scalars_template = {
+    "telemetry.test.string_kind": STRING_SCALAR_VALUE
+}
+
 ignored_scalars_template = {
     "browser.engagement.navigation": SCALAR_VALUE,
-    "browser.engagement.navigation.test": SCALAR_VALUE,
-    "telemetry.test.string_kind": "IGNORED_STRING"
+    "browser.engagement.navigation.test": SCALAR_VALUE
 }
 
 keyed_scalars_template = {
@@ -166,8 +171,14 @@ def generate_payload(dimensions, aggregated_child_histograms):
     child_payloads = [{"simpleMeasurements": simple_measurements_template}
                       for i in range(NUM_CHILDREN_PER_PING)]
 
-    scalars = dict(chain(scalars_template.iteritems(), ignored_scalars_template.iteritems()))
-    keyed_scalars = dict(chain(keyed_scalars_template.iteritems(), ignored_keyed_scalars_template.iteritems()))
+    scalars = dict(chain(
+        numeric_scalars_template.iteritems(),
+        string_scalars_template.iteritems(),
+        ignored_scalars_template.iteritems()))
+
+    keyed_scalars = dict(chain(
+        keyed_scalars_template.iteritems(),
+        ignored_keyed_scalars_template.iteritems()))
 
     processes_payload = {
         u"parent": {

--- a/tests/test_aggregator.py
+++ b/tests/test_aggregator.py
@@ -2,7 +2,7 @@ import pyspark
 import logging
 import pandas as pd
 
-from mozaggregator.aggregator import _aggregate_metrics, SIMPLE_MEASURES_PREFIX, NUMERIC_SCALARS_PREFIX, COUNT_HISTOGRAM_PREFIX, PROCESS_TYPES
+from mozaggregator.aggregator import _aggregate_metrics, SIMPLE_MEASURES_PREFIX, SCALARS_PREFIX, COUNT_HISTOGRAM_PREFIX, PROCESS_TYPES
 from collections import defaultdict
 from dataset import *
 
@@ -87,33 +87,43 @@ def test_simple_measurements():
 
 def test_numerical_scalars():
     metric_count = defaultdict(lambda: defaultdict(int))
-    scalar_metrics, keyed_scalar_metrics = set([k.upper() for k in scalars_template.keys()]), set([k.upper() for k in keyed_scalars_template.keys()])
+    numeric_scalar_metrics = set([k.upper() for k in numeric_scalars_template.keys()])
+    keyed_scalar_metrics =  set([k.upper() for k in keyed_scalars_template.keys()])
+    string_scalar_metrics = set([k.upper() for k in string_scalars_template.keys()])
 
     for aggregate in build_id_aggregates:
         for key, value in aggregate[1].iteritems():
             metric, label, process_type = key
 
-            if metric.startswith(NUMERIC_SCALARS_PREFIX):
-                orig_name = metric.replace(NUMERIC_SCALARS_PREFIX + '_', "")
-                assert(orig_name in scalar_metrics | keyed_scalar_metrics)
+            if metric.startswith(SCALARS_PREFIX):
+                orig_name = metric.replace(SCALARS_PREFIX + '_', "")
+                assert(orig_name in numeric_scalar_metrics | keyed_scalar_metrics | string_scalar_metrics)
 
-                if orig_name in scalar_metrics:
+                if orig_name in numeric_scalar_metrics:
                     assert(label == "")
-                else:
-                    assert(label != "")
+                elif orig_name in keyed_scalar_metrics:
+                    keys = keyed_scalars_template[orig_name.lower()].keys()
+                    assert label.lower() in keys, "Metric {}: {} should be in {}, but was not".format(orig_name, label, ", ".join(keys))
                     metric = "{}_{}".format(metric, label)
+                elif orig_name in string_scalar_metrics:
+                    assert(label == STRING_SCALAR_VALUE)
 
                 metric_count[metric][process_type] += 1
                 assert value["count"] == expected_count(process_type, True), "Expected {}, Got {}, Process {}".format(expected_count(process_type, True), value["count"], process_type)
-                assert(value["sum"] == value["count"] * SCALAR_VALUE)
-                assert(value["histogram"][str(NUMERIC_SCALAR_BUCKET)] == value["count"])
+                if orig_name in numeric_scalar_metrics | keyed_scalar_metrics:
+                    assert(value["sum"] == value["count"] * SCALAR_VALUE)
+                    assert(value["histogram"][str(NUMERIC_SCALAR_BUCKET)] == value["count"])
+                else:
+                    assert(value["sum"] == value["count"])
+                    assert value["histogram"][STRING_SCALAR_BUCKET] == value["count"], "Metric {}: histogram={}, bucket={}, expected_count={}".format(orig_name, str(value["histogram"]), STRING_SCALAR_BUCKET, value["count"])
 
     keyed_scalars_template_len = len([key for metric, dic in keyed_scalars_template.iteritems() for key in dic])
-    assert len(metric_count) == len(scalars_template) + keyed_scalars_template_len
+    assert len(metric_count) == len(numeric_scalars_template) + len(string_scalars_template) + keyed_scalars_template_len
     for metric, process_counts in metric_count.iteritems():
         assert(process_counts.viewkeys() == PROCESS_TYPES)
         for v in process_counts.values():
           assert(v == len(build_id_aggregates))
+
 
 def test_classic_histograms():
     metric_count = defaultdict(lambda: defaultdict(int))

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -5,7 +5,8 @@ import pandas as pd
 import json
 import re
 
-from mozaggregator.aggregator import _aggregate_metrics, COUNT_HISTOGRAM_LABELS, SIMPLE_MEASURES_LABELS, NUMERIC_SCALARS_LABELS, SIMPLE_MEASURES_PREFIX, SCALARS_PREFIX
+from mozaggregator.constants import *
+from mozaggregator.aggregator import _aggregate_metrics
 from mozaggregator.db import _create_connection, submit_aggregates
 from mozaggregator.service import SUBMISSION_DATE_ETAG, CLIENT_CACHE_SLACK_SECONDS
 from mozaggregator import config


### PR DESCRIPTION
This change adds string scalar aggregates, which will then have
a histogram, sum, and count - which should all be the same value
for any string.

See bug 1376493.