### PR TITLE
Bug 1403994 - Aggregate histograms of different lengths correctly

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@
 from setuptools import setup
 
 setup(name='python_mozaggregator',
-    version='0.2.6.9',
+    version='0.2.6.10',
     author='Roberto Agostino Vitillo',
     author_email='rvitillo@mozilla.com',
     description='Telemetry aggregation job',

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -296,6 +296,15 @@ def test_build_id_etag_header_ignored():
     assert reply.ok
     assert reply.status_code == 200, "Etag should be ignored for build id"
 
+def test_aggregate_histograms():
+    conn = _create_connection()
+    cursor = conn.cursor()
+    cursor.execute("""
+        SELECT aggregate_histograms(t.histos) AS aggregates
+        FROM (VALUES (ARRAY[1,1,1,1]), (ARRAY[1,1,1,1,1])) AS t(histos)
+    """)
+    res = cursor.fetchall()
+    assert res == [([2, 2, 1, 2, 2],)]
 
 @nottest
 def test_histogram(prefix, channel, version, dates, metric, value, expected_count):


### PR DESCRIPTION
This separates aggregating the histogram buckets (keys 0:n-2)
from the sum and ping counts (keys n-1 and n). This way we can
add new buckets without the new values polluting those last
two buckets.

Testing: I don't really have a way to add a direct test of this situation, which is a change in the histogram definition. As such I've tested that this aggregate function works as expected, and when used on the histograms of different lengths should aggregate them correctly as well.