### PR TITLE
Make build_id insertions add histograms correctly

### DIFF
--- a/mozaggregator/sql.py
+++ b/mozaggregator/sql.py
@@ -53,7 +53,7 @@ begin
 
     -- Update existing tuples and delete matching rows from the staging table
     execute 'with merge as (update ' || tablename || ' as dest
-                            set histogram = aggregate_arrays(dest.histogram, src.histogram)
+                            set histogram = aggregate_histogram_arrays(dest.histogram, src.histogram)
                             from ' || stage_table || ' as src
                             where dest.dimensions = src.dimensions
                             returning dest.*)

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@
 from setuptools import setup
 
 setup(name='python_mozaggregator',
-    version='0.2.6.10',
+    version='0.2.6.11',
     author='Roberto Agostino Vitillo',
     author_email='rvitillo@mozilla.com',
     description='Telemetry aggregation job',


### PR DESCRIPTION
Bug 1403994

Previously, old build_id histograms would merge with new ones
by just adding; but instead we want to first add the histograms,
then the sums and counts separately.

Unfortunately this means that [0] did not fix historical build_id
aggregates. Those are broken in the db for good.

[0] https://github.com/mozilla/python_mozaggregator/pull/57