### PR TITLE
Fix Use Counters at the Service Level

### DIFF
--- a/mozaggregator/aggregator.py
+++ b/mozaggregator/aggregator.py
@@ -170,48 +170,7 @@ def _extract_main_histograms(state, histograms, process_type):
     if not isinstance(histograms, dict):
         return
 
-    # Deal with USE_COUNTER2_ histograms, see Bug 1204994
-    pages_destroyed = histograms.get("TOP_LEVEL_CONTENT_DOCUMENTS_DESTROYED", {})
-    if not isinstance(pages_destroyed, dict):
-        pages_destroyed = {}
-
-    pages_destroyed = pages_destroyed.get("sum", -1)
-    if not isinstance(pages_destroyed, (int, long)):
-        pages_destroyed = -1
-
-    docs_destroyed = histograms.get("CONTENT_DOCUMENTS_DESTROYED", {})
-    if not isinstance(docs_destroyed, dict):
-        docs_destroyed = {}
-
-    docs_destroyed = docs_destroyed.get("sum", -1)
-    if not isinstance(docs_destroyed, (int, long)):
-        docs_destroyed = -1
-
     for histogram_name, histogram in histograms.iteritems():
-        if not isinstance(histogram, dict):
-            continue
-
-        if pages_destroyed >= 0 and histogram_name.startswith("USE_COUNTER2_") and histogram_name.endswith("_PAGE"):
-            values = histogram.get("values", {})
-            if not isinstance(values, dict):
-                continue
-
-            used = values.get("1", -1)
-            if not isinstance(used, (int, long)) or used <= 0:
-                continue
-
-            histogram["values"]["0"] = pages_destroyed - used
-        elif docs_destroyed >= 0 and histogram_name.startswith("USE_COUNTER2_") and histogram_name.endswith("_DOCUMENT"):
-            values = histogram.get("values", {})
-            if not isinstance(values, dict):
-                continue
-
-            used = values.get("1", -1)
-            if not isinstance(used, (int, long)) or used <= 0:
-                continue
-
-            histogram["values"]["0"] = docs_destroyed - used
-
         _extract_histogram(state, histogram, histogram_name, u"", process_type)
 
 def _extract_keyed_histograms(state, histogram_name, histograms, process_type):

--- a/mozaggregator/sql.py
+++ b/mozaggregator/sql.py
@@ -155,6 +155,31 @@ begin
 end
 $$ language plpgsql strict;
 
+create or replace function batched_get_use_counter(prefix text, channel text, version text, dates text[], denominator_dimensions jsonb, denominator_new_dimensions jsonb, dimensions jsonb, new_dimensions jsonb DEFAULT '{"metric":"METRIC???"}') returns table(date text, label text, histogram bigint[]) as $$
+begin
+    return query
+        select t2.date,
+        coalesce(t1.label, ''),
+        case
+            when t1.histogram is null then ARRAY[
+                t2.histogram[array_length(t2.histogram, 1) - 1],
+                0,
+                0,
+                0,
+                t2.histogram[array_length(t2.histogram, 1)]]
+            when t2.histogram is null then t1.histogram
+            else ARRAY[
+                t2.histogram[array_length(t2.histogram, 1) - 1] - t1.histogram[2] - t1.histogram[3],
+                t1.histogram[2],
+                t1.histogram[3],
+                t1.histogram[4],
+                t1.histogram[5]]
+        end
+        from batched_get_metric(prefix, channel, version, dates, dimensions, new_dimensions) t1
+        full outer join batched_get_metric(prefix, channel, version, dates, denominator_dimensions, denominator_new_dimensions) t2
+        on t1.date = t2.date;
+end
+$$ language plpgsql strict;
 
 create or replace function list_buildids(prefix text, channel text) returns table(version text, buildid text) as $$
 begin

--- a/tests/test_aggregator.py
+++ b/tests/test_aggregator.py
@@ -162,37 +162,6 @@ def test_count_histograms():
           assert(v == len(build_id_aggregates))
 
 
-def test_use_counter2_histogram():
-    metric_count = defaultdict(lambda: defaultdict(int))
-    histograms = {k: v for k, v in histograms_template.iteritems() if k.startswith("USE_COUNTER2_") and v is not None}
-
-    pages_destroyed = histograms_template["TOP_LEVEL_CONTENT_DOCUMENTS_DESTROYED"]["sum"]
-    docs_destroyed = histograms_template["CONTENT_DOCUMENTS_DESTROYED"]["sum"]
-
-    for aggregate in build_id_aggregates:
-        for key, value in aggregate[1].iteritems():
-            metric, label, process_type = key
-            histogram = histograms.get(metric, None)
-
-            if histogram:
-                metric_count[metric][process_type] += 1
-                assert(label == "")
-                assert(value["count"] == expected_count(process_type))
-                assert(value["sum"] == value["count"]*histogram["sum"])
-
-                if metric.endswith("_DOCUMENT"):
-                    assert(value["histogram"]["0"] == value["count"]*(docs_destroyed - histogram["values"]["1"]))
-                else:
-                    assert(value["histogram"]["0"] == value["count"]*(pages_destroyed - histogram["values"]["1"]))
-
-
-    assert len(metric_count) == len(histograms)
-    for process_counts in metric_count.values():
-        assert(process_counts.viewkeys() == PROCESS_TYPES)
-        for v in process_counts.values():
-          assert(v == len(build_id_aggregates))
-
-
 def test_keyed_histograms():
     metric_count = defaultdict(lambda: defaultdict(int))
 

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -151,6 +151,30 @@ def test_build_id_metrics():
                 test_keyed_histogram("build_id", channel, version, template_build_id, metric, histograms, histogram_expected_count)
 
 
+def test_absent_use_counter():
+    # A use counter that isn't in the aggregator should still get a response from the service
+    # This is a side-effect of bug 1412384
+    channel = ping_dimensions["channel"][0]
+    version = ping_dimensions["version"][0].split('.')[0]
+    template_build_id = [ping_dimensions["build_id"][0][:-6]]
+    metric = "USE_COUNTER2_SIR_NOT_APPEARING_IN_THIS_DOCUMENT"
+    value = {u'bucket_count': 3,
+             u'histogram_type': 2,
+             u'range': [1, 2],
+             u'values': {u'0': 640, u'1': 0, u'2': 0},
+             u'count': 0,
+             u'sum': 0,
+    }
+
+    expected_count = 1
+    for dimension, values in ping_dimensions.iteritems():
+        if dimension not in ["channel", "version", "build_id"]:
+            expected_count *= len(values)
+
+    histogram_expected_count = NUM_PINGS_PER_DIMENSIONS * expected_count
+
+    test_histogram("build_id", channel, version, template_build_id, metric, value, histogram_expected_count)
+
 def test_submission_dates_metrics():
     template_channel = ping_dimensions["channel"]
     template_version = [x.split('.')[0] for x in ping_dimensions["version"]]


### PR DESCRIPTION
[bug 1412382](https://bugzilla.mozilla.org/show_bug.cgi?id=1412382)

Use counters in the database are wrong, and have been since [bug 1204994](https://bugzilla.mozilla.org/show_bug.cgi?id=1204994) changed
_extract_main_histograms. It only counted "False" values in pings that had at
least one "True" value (because if there were only "False" values, we didn't
send a use counter in that ping).

This fixes this by subbing in the False value from
(TOP_LEVEL_)CONTENT_DOCUMENTS_DESTROYED, which has the correct number.

This results in an interesting side-effect that use counters that don't exist
will get valid responses from the service. This is because the service can't
tell the difference between a use counter that doesn't exist and one that just
didn't happen to have a single 'True' value in that row in that table.

This is beneficial for testing, so that I don't have to manipulate
histograms_template or generate_payload in dataset.py to be able to support
probes that aren't in every ping. The math for expected_count in test_db
would only get worse.

Instead I can ask for a use counter that doesn't exist and ensure that it
reports the correct number of False values and the correct count.