### PR TITLE
Increase version to 0.3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@
 from setuptools import setup
 
 setup(name='python_mozaggregator',
-    version='0.2.6.11',
+    version='0.3.0.0',
     author='Roberto Agostino Vitillo',
     author_email='rvitillo@mozilla.com',
     description='Telemetry aggregation job',


### PR DESCRIPTION
The recent change of use counters necessitates a minor version
bump, since the API remains the same but the data returned
is different.