### PR TITLE
Bug 1472621 Truncate aggregates on bigint overflow

### DIFF
--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -99,3 +99,11 @@ def test_aggregate_histograms():
     """)
     res = cursor.fetchall()
     assert res == [([2, 2, 1, 2, 2],)]
+
+
+def test_cast_array_to_bigint():
+    conn = _create_connection()
+    cursor = conn.cursor()
+    cursor.execute("SELECT cast_array_to_bigint_safe(ARRAY[-9223372036854775809, 9223372036854775808, 12]);")
+    res = cursor.fetchall()
+    assert res == [([-9223372036854775808L,9223372036854775807L,12L],)]


### PR DESCRIPTION
This logs warnings in PostgreSQL whenever we truncate, including the pre-truncation value so we have evidence of how severe the truncation is.