### PR TITLE
Bug 1474590 Client-side logging for database warnings

### DIFF
--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -7,3 +7,4 @@ nose==1.3.7
 pycodestyle==2.3.1
 pyflakes==1.6.0
 requests==2.18.4
+testfixtures==6.2.0


### PR DESCRIPTION
Note that this continues to log messages on the DB side, so does not address concern (2) in https://github.com/mozilla/python_mozaggregator/pull/99#pullrequestreview-135824877 but I think the simplicity of this approach vs. a purely client-side approach makes it a better option.