### PR TITLE
Add drop tables query

### DIFF
--- a/queries/drop_non_quantum.sql
+++ b/queries/drop_non_quantum.sql
@@ -1,0 +1,50 @@
+CREATE OR REPLACE FUNCTION try_cast_int(p_in TEXT, p_default INT default null)
+RETURNS INT
+LANGUAGE plpgsql;
+AS $$
+BEGIN
+  BEGIN
+    RETURN $1::INT;
+  EXCEPTION 
+    WHEN others THEN
+       RETURN p_default;
+  END;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION reverse(TEXT)
+RETURNS TEXT
+AS $$
+SELECT array_to_string(ARRAY(
+  SELECT SUBSTRING($1, s.i,1) FROM generate_series(LENGTH($1), 1, -1) AS s(i)
+  ), '');
+$$ LANGUAGE SQL IMMUTABLE STRICT;
+
+CREATE OR REPLACE FUNCTION drop_tables_before_date(IN _schema TEXT, IN _min_date INT) 
+RETURNS void 
+LANGUAGE plpgsql
+AS
+$$
+DECLARE
+    row record;
+BEGIN
+    FOR row IN 
+        SELECT
+            table_schema,
+            table_name
+        FROM
+            information_schema.tables
+        WHERE
+            table_type = 'BASE TABLE'
+        AND
+            table_schema = _schema
+        AND
+            try_cast_int(reverse(split_part(reverse(table_name), '_', 1)), _min_date-1) < _min_date
+    LOOP
+        EXECUTE 'DROP TABLE ' || quote_ident(row.table_schema) || '.' || quote_ident(row.table_name);
+        RAISE INFO 'Dropped table: %', quote_ident(row.table_schema) || '.' || quote_ident(row.table_name);
+    END LOOP;
+END;
+$$;
+
+SELECT drop_tables_before_date('public', '20180101');


### PR DESCRIPTION
Before we migrate to GCP, we'd like to trim the database a bit. This query should remove all data from before `20180101`.

We will keep backups of data before then. If a use-case comes up for that data, we can spin up a database and query it there.

I've tested this query by running the following, which is almost a replica of what the drop_tables is doing. It correctly returned the `max_date` as `20150331`. Running with `20180101` correctly gives `20180101`.

There is a nice side benefit of this query, which is it drops all those "weird" builds that we never use anyways - they're not queryable from the service.
```
CREATE OR REPLACE FUNCTION try_cast_int(p_in TEXT, p_default INT default null)
RETURNS INT
LANGUAGE plpgsql
AS $$
BEGIN
  BEGIN
    RETURN $1::INT;
  EXCEPTION 
    WHEN others THEN
       RETURN p_default;
  END;
END;
$$;

CREATE OR REPLACE FUNCTION reverse(TEXT)
RETURNS TEXT
AS $$
SELECT array_to_string(ARRAY(
  SELECT SUBSTRING($1, s.i,1) FROM generate_series(LENGTH($1), 1, -1) AS s(i)
  ), '');
$$ LANGUAGE SQL IMMUTABLE STRICT;

SELECT
    max(try_cast_int(reverse(split_part(reverse(table_name), '_', 1)), -1)) AS max_date
FROM
    information_schema.tables
WHERE
    table_type = 'BASE TABLE'
AND
    table_schema = 'public'
AND
    try_cast_int(reverse(split_part(reverse(table_name), '_', 1)), 20150401-1) < 20150401
```