### PR TITLE
 Bug 1572112 - Add support for GCP payload_bytes_decoded to python_mozaggregator

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,6 +39,11 @@ RUN pip install --upgrade pip && \
 ENV PYSPARK_PYTHON=python \
     SPARK_HOME=/usr/local/lib/python2.7/site-packages/pyspark
 
+RUN wget --directory-prefix $SPARK_HOME/jars/ https://storage.googleapis.com/spark-lib/bigquery/spark-bigquery-latest.jar
+RUN wget --directory-prefix $SPARK_HOME/jars/ https://storage.googleapis.com/hadoop-lib/gcs/gcs-connector-hadoop2-latest.jar
+RUN wget --directory-prefix $SPARK_HOME/jars/ https://repo1.maven.org/maven2/org/apache/hadoop/hadoop-aws/2.7.3/hadoop-aws-2.7.3.jar
+RUN wget --directory-prefix $SPARK_HOME/jars/ https://repo1.maven.org/maven2/com/amazonaws/aws-java-sdk/1.7.4/aws-java-sdk-1.7.4.jar
+
 # Switch back to home directory
 WORKDIR /app
 

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -45,6 +45,11 @@ RUN pip install --upgrade pip && \
 ENV PYSPARK_PYTHON=python \
     SPARK_HOME=/usr/local/lib/python2.7/site-packages/pyspark
 
+RUN wget --directory-prefix $SPARK_HOME/jars/ https://storage.googleapis.com/spark-lib/bigquery/spark-bigquery-latest.jar
+RUN wget --directory-prefix $SPARK_HOME/jars/ https://storage.googleapis.com/hadoop-lib/gcs/gcs-connector-hadoop2-latest.jar
+RUN wget --directory-prefix $SPARK_HOME/jars/ https://repo1.maven.org/maven2/org/apache/hadoop/hadoop-aws/2.7.3/hadoop-aws-2.7.3.jar
+RUN wget --directory-prefix $SPARK_HOME/jars/ https://repo1.maven.org/maven2/com/amazonaws/aws-java-sdk/1.7.4/aws-java-sdk-1.7.4.jar
+
 # Switch back to home directory
 WORKDIR /app
 COPY . /app

--- a/bin/dataproc.sh
+++ b/bin/dataproc.sh
@@ -1,0 +1,96 @@
+#!/bin/bash
+
+# A testing script for verifying the spark-bigquery connector with the existing
+# mozaggregator code. This requires `gcloud` to be configured to point at a
+# sandbox project for reading data from `payload_bytes_decoded`.
+
+set -e
+
+REGION=us-west1
+MODULE="python_mozaggregator"
+NUM_WORKERS=${NUM_WORKERS:-1}
+
+
+function bootstrap() {
+    local bucket=$1
+
+    # create the package artifacts
+    rm -rf dist build
+    python setup.py bdist_egg
+    gsutil cp "dist/${MODULE}*.egg" "gs://${bucket}/bootstrap/${MODULE}.egg"
+
+    # create the initialization script and runner
+    mkdir -p bootstrap
+    cd bootstrap
+    echo "apt install --yes python-dev" > install-python-dev.sh
+    tee mozaggregator-runner.py >/dev/null << EOF
+# This runner has been auto-generated from mozilla/python_mozaggregator/bin/dataproc.sh.
+# Any changes made to the runner file will be over-written on subsequent runs.
+from mozaggregator import cli
+
+try:
+    cli.entry_point(auto_envvar_prefix="MOZETL")
+except SystemExit:
+    # avoid calling sys.exit() in databricks
+    # http://click.palletsprojects.com/en/7.x/api/?highlight=auto_envvar_prefix#click.BaseCommand.main
+    pass
+EOF
+    cd ..
+    gsutil cp bootstrap/* "gs://${bucket}/bootstrap/"
+}
+
+
+function delete_cluster() {
+    local cluster_id=$1
+    gcloud dataproc clusters delete ${cluster_id} --region=${REGION}
+}
+
+
+function create_cluster() {
+    local cluster_id=$1
+    local bucket=$2
+    requirements=$(tr "\n" " " < requirements/build.txt)
+
+    function cleanup {
+        delete_cluster ${cluster_id}
+    }
+    trap cleanup EXIT
+
+    gcloud dataproc clusters create ${cluster_id} \
+        --image-version 1.3 \
+        --num-preemptible-workers ${NUM_WORKERS} \
+        --properties ^#^spark:spark.jars=gs://spark-lib/bigquery/spark-bigquery-latest.jar#spark:spark.hadoop.fs.s3a.access.key=${AWS_ACCESS_KEY_ID}#spark:spark.hadoop.fs.s3a.secret.key=${AWS_SECRET_ACCESS_KEY} \
+        --metadata "PIP_PACKAGES=${requirements}" \
+        --initialization-actions \
+            gs://${bucket}/bootstrap/install-python-dev.sh,gs://dataproc-initialization-actions/python/pip-install.sh \
+        --region=${REGION}
+}
+
+
+function submit() {
+    cluster_id=$1
+    bucket=$2
+    # pass the rest of the parameters from the main function
+    shift 2
+    gcloud dataproc jobs submit pyspark \
+        gs://${bucket}/bootstrap/mozaggregator-runner.py \
+        --cluster ${cluster_id} \
+        --region ${REGION} \
+        --py-files=gs://${bucket}/bootstrap/${MODULE}.egg \
+        -- "$@"
+}
+
+
+function main() {
+    cd "$(dirname "$0")/.."
+    bucket=$(gcloud config get-value project)
+    cluster_id=test-mozaggregator
+    bootstrap $bucket
+    create_cluster $cluster_id $bucket
+    submit $cluster_id $bucket "$@"
+}
+
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    main "$@"
+fi

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '2'
+version: '2.1'
 
 services:
   db:
@@ -10,10 +10,16 @@ services:
       dockerfile: Dockerfile.dev
     ports:
       - "5000:5000"
-    volumes:
-      - $PWD:/app
     depends_on:
       - db
     links:
       - db
     command: serve
+    volumes:
+      - ./:/app/
+      - ${GOOGLE_APPLICATION_CREDENTIALS:-./setup.py}:/app/.credentials
+    environment:
+      - GOOGLE_APPLICATION_CREDENTIALS=/app/.credentials
+      - PROJECT_ID
+      - AWS_ACCESS_KEY_ID
+      - AWS_SECRET_ACCESS_KEY

--- a/mozaggregator/bigquery.py
+++ b/mozaggregator/bigquery.py
@@ -1,0 +1,119 @@
+import json
+import zlib
+
+from datetime import datetime, timedelta
+
+from pyspark.sql import Row, SparkSession
+
+
+class BigQueryDataset:
+    def __init__(self):
+        self.spark = SparkSession.builder.getOrCreate()
+
+    @staticmethod
+    def _date_add(date_ds, days):
+        dt = datetime.strptime(date_ds, "%Y%m%d")
+        return datetime.strftime(dt + timedelta(days), "%Y-%m-%d")
+
+    @staticmethod
+    def _extract_payload(row):
+        """
+        The schema for the `payload_bytes_decoded` table is listed for reference.
+
+            root
+            |-- client_id: string (nullable = true)
+            |-- document_id: string (nullable = true)
+            |-- metadata: struct (nullable = true)
+            |    |-- document_namespace: string (nullable = true)
+            |    |-- document_type: string (nullable = true)
+            |    |-- document_version: string (nullable = true)
+            |    |-- geo: struct (nullable = true)
+            |    |    |-- city: string (nullable = true)
+            |    |    |-- country: string (nullable = true)
+            |    |    |-- db_version: string (nullable = true)
+            |    |    |-- subdivision1: string (nullable = true)
+            |    |    |-- subdivision2: string (nullable = true)
+            |    |-- header: struct (nullable = true)
+            |    |    |-- date: string (nullable = true)
+            |    |    |-- dnt: string (nullable = true)
+            |    |    |-- x_debug_id: string (nullable = true)
+            |    |    |-- x_pingsender_version: string (nullable = true)
+            |    |-- uri: struct (nullable = true)
+            |    |    |-- app_build_id: string (nullable = true)
+            |    |    |-- app_name: string (nullable = true)
+            |    |    |-- app_update_channel: string (nullable = true)
+            |    |    |-- app_version: string (nullable = true)
+            |    |-- user_agent: struct (nullable = true)
+            |    |    |-- browser: string (nullable = true)
+            |    |    |-- os: string (nullable = true)
+            |    |    |-- version: string (nullable = true)
+            |-- normalized_app_name: string (nullable = true)
+            |-- normalized_channel: string (nullable = true)
+            |-- normalized_country_code: string (nullable = true)
+            |-- normalized_os: string (nullable = true)
+            |-- normalized_os_version: string (nullable = true)
+            |-- payload: binary (nullable = true)
+            |-- sample_id: long (nullable = true)
+            |-- submission_timestamp: timestamp (nullable = true)
+        """
+        data = json.loads(zlib.decompress(bytes(row.payload), 15 + 32))
+        # add `meta` fields for backwards compatibility
+        data["meta"] = {
+            "submissionDate": datetime.strftime(row.submission_timestamp, "%Y%m%d"),
+            "sampleId": row.sample_id,
+            # following 4 fields necessary for mobile_aggregates
+            "normalizedChannel": row.normalized_channel,
+            "appVersion": row.metadata.uri.app_version,
+            "appBuildId": row.metadata.uri.app_build_id,
+            "appName": row.metadata.uri.app_name,
+        }
+        return data
+
+    def load(
+        self,
+        project_id,
+        dataset_id,
+        doc_type,
+        submission_date,
+        channels=None,
+        filter_clause=None,
+        fraction=1,
+        doc_version="v4",
+    ):
+
+        start = self._date_add(submission_date, 0)
+        end = self._date_add(submission_date, 1)
+
+        date_clause = "submission_timestamp >= '{start}' AND submission_timestamp < '{end}'".format(
+            start=start, end=end
+        )
+
+        filters = [date_clause]
+        if channels:
+            # build up a clause like "(normalized_channel = 'nightly' OR normalized_channel = 'beta')"
+            clauses = [
+                "normalized_channel = '{}'".format(channel) for channel in channels
+            ]
+            joined = "({})".format(" OR ".join(clauses))
+            filters.append(joined)
+        if filter_clause:
+            filters.append(filter_clause)
+
+        df = (
+            self.spark.read.format("bigquery")
+            # Assumes the namespace is telemetry
+            .option(
+                "table",
+                "{project_id}.{dataset_id}.telemetry_telemetry__{doc_type}_{doc_version}".format(
+                    project_id=project_id,
+                    dataset_id=dataset_id,
+                    doc_type=doc_type,
+                    doc_version=doc_version,
+                ),
+            )
+            .option("filter", " AND ".join(filters))
+            .load()
+        )
+
+        # Size of the RDD sample is not deterministic
+        return df.rdd.map(self._extract_payload).sample(False, fraction)

--- a/mozaggregator/cli.py
+++ b/mozaggregator/cli.py
@@ -18,30 +18,59 @@ def entry_point():
 @click.command()
 @click.option("--date", type=str, default=DS_NODASH_YESTERDAY)
 @click.option("--channels", type=str, default="nightly")
+@click.option(
+    "--credentials-protocol", type=click.Choice(["file", "s3", "gcs"]), default="s3"
+)
 @click.option("--credentials-bucket", type=str, required=True)
 @click.option("--credentials-prefix", type=str, required=True)
 @click.option("--num-partitions", type=int, default=10000)
+@click.option(
+    "--source", type=click.Choice(["bigquery", "moztelemetry"]), default="moztelemetry"
+)
+@click.option(
+    "--project-id", envvar="PROJECT_ID", type=str, default="moz-fx-data-shared-prod"
+)
+@click.option("--dataset-id", type=str, default="payload_bytes_decoded")
 def run_aggregator(
-    date, channels, credentials_bucket, credentials_prefix, num_partitions
+    date,
+    channels,
+    credentials_protocol,
+    credentials_bucket,
+    credentials_prefix,
+    num_partitions,
+    source,
+    project_id,
+    dataset_id,
 ):
+    spark = SparkSession.builder.getOrCreate()
 
     # Mozaggregator expects a series of POSTGRES_* variables in order to connect
     # to a db instance; we pull them into the environment now by reading an
-    # object from S3.
-    s3 = boto3.resource("s3")
-    obj = s3.Object(credentials_bucket, credentials_prefix)
-    creds = json.loads(obj.get()["Body"].read().decode("utf-8"))
+    # object from a file system.
+    def create_path(protocol, bucket, prefix):
+        mapping = {"file": "file", "s3": "s3a", "gcs": "gs"}
+        return "{protocol}://{bucket}/{prefix}".format(
+            protocol=mapping[protocol], bucket=bucket, prefix=prefix
+        )
+
+    path = create_path(credentials_protocol, credentials_bucket, credentials_prefix)
+    creds = spark.read.json(path, multiLine=True).first().asDict()
     for k, v in creds.items():
         environ[k] = v
 
     # Attempt a database connection now so we can fail fast if credentials are broken.
     db._preparedb()
 
-    spark = SparkSession.builder.getOrCreate()
     channels = [channel.strip() for channel in channels.split(",")]
     print("Running job for {}".format(date))
     aggregates = aggregator.aggregate_metrics(
-        spark.sparkContext, channels, date, num_reducers=num_partitions
+        spark.sparkContext,
+        channels,
+        date,
+        num_reducers=num_partitions,
+        source=source,
+        project_id=project_id,
+        dataset_id=dataset_id,
     )
     print("Number of build-id aggregates: {}".format(aggregates[0].count()))
     print("Number of submission date aggregates: {}".format(aggregates[1].count()))
@@ -55,13 +84,26 @@ def run_aggregator(
 @click.option("--channels", type=str, default="nightly")
 @click.option("--output", type=str, default="s3://telemetry-parquet/aggregates_poc/v1")
 @click.option("--num-partitions", type=int, default=10000)
-def run_parquet(date, channels, output, num_partitions):
+@click.option(
+    "--source", type=click.Choice(["bigquery", "moztelemetry"]), default="moztelemetry"
+)
+@click.option(
+    "--project-id", envvar="PROJECT_ID", type=str, default="moz-fx-data-shared-prod"
+)
+@click.option("--dataset-id", type=str, default="payload_bytes_decoded")
+def run_parquet(date, channels, output, num_partitions, source, project_id, dataset_id):
     spark = SparkSession.builder.getOrCreate()
     channels = [channel.strip() for channel in channels.split(",")]
 
     print("Running job for {}".format(date))
     aggregates = parquet.aggregate_metrics(
-        spark.sparkContext, channels, date, num_reducers=num_partitions
+        spark.sparkContext,
+        channels,
+        date,
+        num_reducers=num_partitions,
+        source=source,
+        project_id=project_id,
+        dataset_id=dataset_id,
     )
     print("Number of build-id aggregates: {}".format(aggregates[0].count()))
     print("Number of submission date aggregates: {}".format(aggregates[1].count()))
@@ -79,12 +121,24 @@ def run_parquet(date, channels, output, num_partitions):
     ),
 )
 @click.option("--num-partitions", type=int, default=10000)
-def run_mobile(date, output, num_partitions):
+@click.option(
+    "--source", type=click.Choice(["bigquery", "moztelemetry"]), default="moztelemetry"
+)
+@click.option(
+    "--project-id", envvar="PROJECT_ID", type=str, default="moz-fx-data-shared-prod"
+)
+@click.option("--dataset-id", type=str, default="payload_bytes_decoded")
+def run_mobile(date, output, num_partitions, source, project_id, dataset_id):
     spark = SparkSession.builder.getOrCreate()
 
     print("Running job for {}".format(date))
     agg_metrics = mobile.aggregate_metrics(
-        spark.sparkContext, date, num_partitions=num_partitions
+        spark.sparkContext,
+        date,
+        num_partitions=num_partitions,
+        source=source,
+        project_id=project_id,
+        dataset_id=dataset_id,
     )
     aggs = mobile.get_aggregates_dataframe(spark, agg_metrics)
     mobile.write_parquet(aggs, output)

--- a/mozaggregator/cli.py
+++ b/mozaggregator/cli.py
@@ -5,8 +5,6 @@ from os import environ
 import click
 from pyspark.sql import SparkSession
 
-import boto3
-
 from . import aggregator, db, parquet, mobile
 
 DS_NODASH_YESTERDAY = datetime.strftime(datetime.utcnow() - timedelta(1), "%Y%m%d")

--- a/requirements/build.txt
+++ b/requirements/build.txt
@@ -31,3 +31,4 @@ python-snappy==0.5.3
 scipy==1.0.1
 ujson==1.35
 urllib3==1.24.2
+requests==2.22.0

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -5,8 +5,7 @@ flake8==3.6.0
 mccabe==0.6.1
 pycodestyle==2.4.0
 pyflakes==2.0.0
-requests==2.20.0
 testfixtures==6.3.0
 pytest
 pytest-cov
-moto==1.3.9
+google-cloud-bigquery

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,16 @@
-import pytest
+import os
+
+from google.cloud import bigquery
 from pyspark.sql import SparkSession
+
+import pytest
+from dataset import generate_pings
+from mobile_dataset import generate_mobile_pings
+from utils import (
+    runif_bigquery_testing_enabled,
+    format_payload_bytes_decoded,
+    format_payload_bytes_decoded_mobile,
+)
 
 
 @pytest.fixture()
@@ -13,3 +24,41 @@ def spark():
 @pytest.fixture()
 def sc(spark):
     return spark.sparkContext
+
+
+@runif_bigquery_testing_enabled
+@pytest.fixture
+def bq_testing_table():
+    bq_client = bigquery.Client()
+
+    project_id = os.environ["PROJECT_ID"]
+    dataset_id = "{project_id}.pytest_mozaggregator_test".format(project_id=project_id)
+    bq_client.delete_dataset(dataset_id, delete_contents=True, not_found_ok=True)
+    bq_client.create_dataset(dataset_id)
+
+    schema = bq_client.schema_from_json(
+        os.path.join(os.path.dirname(__file__), "decoded.1.bq")
+    )
+    # use load_table instead of insert_rows to avoid eventual consistency guarantees
+    df = [format_payload_bytes_decoded(ping) for ping in generate_pings()]
+    mobile_df = [
+        format_payload_bytes_decoded_mobile(ping) for ping in generate_mobile_pings()
+    ]
+
+    # create the relevant tables
+    for table_name, df in [
+        ("main_v4", df),
+        ("saved_session_v4", df),
+        ("mobile_metrics_v1", mobile_df),
+    ]:
+        table_id = "{dataset_id}.telemetry_telemetry__{table_name}".format(
+            dataset_id=dataset_id, table_name=table_name
+        )
+        table = bq_client.create_table(bigquery.table.Table(table_id, schema))
+        bq_client.load_table_from_json(
+            df, table, job_config=bigquery.job.LoadJobConfig(schema=schema)
+        ).result()
+
+    yield
+
+    # bq_client.delete_dataset(dataset_id, delete_contents=True, not_found_ok=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -61,4 +61,4 @@ def bq_testing_table():
 
     yield
 
-    # bq_client.delete_dataset(dataset_id, delete_contents=True, not_found_ok=True)
+    bq_client.delete_dataset(dataset_id, delete_contents=True, not_found_ok=True)

--- a/tests/decoded.1.bq
+++ b/tests/decoded.1.bq
@@ -1,0 +1,182 @@
+[
+  {
+    "mode": "NULLABLE",
+    "name": "client_id",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "document_id",
+    "type": "STRING"
+  },
+  {
+    "fields": [
+      {
+        "mode": "NULLABLE",
+        "name": "document_namespace",
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "document_type",
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "document_version",
+        "type": "STRING"
+      },
+      {
+        "fields": [
+          {
+            "mode": "NULLABLE",
+            "name": "city",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "country",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "db_version",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "subdivision1",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "subdivision2",
+            "type": "STRING"
+          }
+        ],
+        "mode": "NULLABLE",
+        "name": "geo",
+        "type": "RECORD"
+      },
+      {
+        "fields": [
+          {
+            "mode": "NULLABLE",
+            "name": "date",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "dnt",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "x_debug_id",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "x_pingsender_version",
+            "type": "STRING"
+          }
+        ],
+        "mode": "NULLABLE",
+        "name": "header",
+        "type": "RECORD"
+      },
+      {
+        "fields": [
+          {
+            "mode": "NULLABLE",
+            "name": "app_build_id",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "app_name",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "app_update_channel",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "app_version",
+            "type": "STRING"
+          }
+        ],
+        "mode": "NULLABLE",
+        "name": "uri",
+        "type": "RECORD"
+      },
+      {
+        "fields": [
+          {
+            "mode": "NULLABLE",
+            "name": "browser",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "os",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "version",
+            "type": "STRING"
+          }
+        ],
+        "mode": "NULLABLE",
+        "name": "user_agent",
+        "type": "RECORD"
+      }
+    ],
+    "mode": "NULLABLE",
+    "name": "metadata",
+    "type": "RECORD"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "normalized_app_name",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "normalized_channel",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "normalized_country_code",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "normalized_os",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "normalized_os_version",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "payload",
+    "type": "BYTES"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "sample_id",
+    "type": "INT64"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "submission_timestamp",
+    "type": "TIMESTAMP"
+  }
+]

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import os
 
 from click.testing import CliRunner
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,0 +1,67 @@
+import base64
+import json
+import os
+import zlib
+from datetime import datetime
+
+
+def format_payload_bytes_decoded(ping):
+    # fields are created in tests/dataset.py
+    return {
+        "normalized_app_name": ping["application"]["name"],
+        "normalized_channel": ping["application"]["channel"],
+        "normalized_os": ping["environment"]["system"]["os"]["name"],
+        "metadata": {
+            "uri": {
+                "app_version": ping["application"]["version"],
+                "app_build_id": ping["application"]["buildId"],
+                "app_name": ping["application"]["name"],
+            }
+        },
+        "sample_id": ping["meta"]["sampleId"],
+        "submission_timestamp": datetime.strptime(
+            ping["meta"]["submissionDate"], "%Y%m%d"
+        ).strftime("%Y-%m-%d %H:%M:%S"),
+        "payload": base64.b64encode(zlib.compress(json.dumps(ping))),
+    }
+
+
+def format_payload_bytes_decoded_mobile(ping):
+    """Format the mobile payload, this requires less meta information than the
+    normal dataset because there is little to no filtering being done in the job.
+
+    Fields are created in tests/mobile_dataset.py.
+    """
+    return {
+        "submission_timestamp": datetime.strptime(
+            ping["meta"]["submissionDate"], "%Y%m%d"
+        ).strftime("%Y-%m-%d %H:%M:%S"),
+        "normalized_channel": ping["meta"]["normalizedChannel"],
+        "metadata": {
+            "uri": {
+                "app_version": str(ping["meta"]["appVersion"]),
+                "app_build_id": ping["meta"]["appBuildId"],
+                "app_name": ping["meta"]["appName"],
+            }
+        },
+        "payload": base64.b64encode(zlib.compress(json.dumps(ping))),
+    }
+
+
+def runif_bigquery_testing_enabled(func):
+    """A decorator that will skip the test if the current environment is not set up for running tests.
+
+        @runif_bigquery_testing_enabled
+        def test_my_function_that_uses_bigquery_spark_connector(table_fixture):
+            ...
+    """
+    # importing this at module scope will break test discoverability
+    import pytest
+
+    bigquery_testing_enabled = os.environ.get(
+        "GOOGLE_APPLICATION_CREDENTIALS"
+    ) and os.environ.get("PROJECT_ID")
+    return pytest.mark.skipif(
+        not bigquery_testing_enabled,
+        reason="requires valid gcp credentials and project id",
+    )(func)


### PR DESCRIPTION
[bug link](https://bugzilla.mozilla.org/show_bug.cgi?id=1572112)

I've generated two datasets that complete successfully for `mobile_metrics_aggregates` and `aggregates_poc`.

```bash
bin/dataproc.sh \
	mobile \
	--output gs://amiyaguchi-dev/mozaggregator/mobile_test/v1/ \
	--num-partitions 200 \
	--date 20191019 \
	--source bigquery \
	--project-id moz-fx-data-shar-nonprod-efed

bin/dataproc.sh \
	parquet \
	--output gs://amiyaguchi-dev/mozaggregator/parquet_test/v1/ \
	--num-partitions 200 \
	--date 20191020 \
	--channels nightly,beta \
	--source bigquery \
	--project-id moz-fx-data-shar-nonprod-efed
```

I've done some very minor testing, but I still need to verify that the resulting aggregates are matching. From a cursory glance, it looks like the `mobile_metrics_aggregates` table hasn't been updated since `2019-09-04`, which aligns to the introduction of https://github.com/mozilla/python_mozaggregator/pull/183. When comparing the `aggregates_poc` dataset against the corresponding parquet dataset, I notice that the values are much lower in the GCP equivalent dataset. More investigation needed.

```python
import pyspark.sql.functions as F
df = spark.read.parquet("gs://amiyaguchi-dev/mozaggregator/parquet_test/")
df.count()
# 711998

df.groupBy("application").agg(F.sum("sum")).show()
"""
+-----------+------------------+                                                
|application|          sum(sum)|
+-----------+------------------+
|    Firefox|231104016310538058|
|     Fennec|   243433609179356|
+-----------+------------------+
"""
```