### PR TITLE
 Bug 1594448 - Add option to aggregator to read from avro

### DIFF
--- a/bin/dataproc.sh
+++ b/bin/dataproc.sh
@@ -57,9 +57,9 @@ function create_cluster() {
     trap cleanup EXIT
 
     gcloud dataproc clusters create ${cluster_id} \
-        --image-version 1.3 \
+        --image-version 1.4 \
         --num-preemptible-workers ${NUM_WORKERS} \
-        --properties ^#^spark:spark.jars=gs://spark-lib/bigquery/spark-bigquery-latest.jar#spark:spark.hadoop.fs.s3a.access.key=${AWS_ACCESS_KEY_ID}#spark:spark.hadoop.fs.s3a.secret.key=${AWS_SECRET_ACCESS_KEY} \
+        --properties ^#^spark:spark.jars=gs://spark-lib/bigquery/spark-bigquery-latest.jar#spark:spark.hadoop.fs.s3a.access.key=${AWS_ACCESS_KEY_ID}#spark:spark.hadoop.fs.s3a.secret.key=${AWS_SECRET_ACCESS_KEY}#spark:spark.jars.packages=org.apache.spark:spark-avro_2.11:2.4.4 \
         --metadata "PIP_PACKAGES=${requirements}" \
         --initialization-actions \
             gs://${bucket}/bootstrap/install-python-dev.sh,gs://dataproc-initialization-actions/python/pip-install.sh \

--- a/mozaggregator/aggregator.py
+++ b/mozaggregator/aggregator.py
@@ -85,7 +85,7 @@ def aggregate_metrics(
             channels,
             "normalized_app_name <> 'Fennec'"
         )
-        fennec_pings = dataset.load(
+        fennec_pings = dataset.load_avro(
             avro_prefix,
             "saved_session",
             submission_date,

--- a/mozaggregator/aggregator.py
+++ b/mozaggregator/aggregator.py
@@ -46,6 +46,7 @@ def aggregate_metrics(
     source="moztelemetry",
     project_id=None,
     dataset_id=None,
+    avro_prefix=None,
     ):
     """ Returns the build-id and submission date aggregates for a given submission date.
 
@@ -70,6 +71,22 @@ def aggregate_metrics(
         fennec_pings = dataset.load(
             project_id,
             dataset_id,
+            "saved_session",
+            submission_date,
+            channels,
+            "normalized_app_name = 'Fennec'"
+        )
+    elif source == "avro" and avro_prefix:
+        dataset = BigQueryDataset()
+        pings = dataset.load_avro(
+            avro_prefix,
+            "main",
+            submission_date,
+            channels,
+            "normalized_app_name <> 'Fennec'"
+        )
+        fennec_pings = dataset.load(
+            avro_prefix,
             "saved_session",
             submission_date,
             channels,

--- a/mozaggregator/bigquery.py
+++ b/mozaggregator/bigquery.py
@@ -144,7 +144,7 @@ class BigQueryDataset:
             filters.append(filter_clause)
 
         df = self.spark.read.format("avro").load(
-            "{prefix}/submission_date={submission_date}/telemetry_{doc_type}_{doc_version}".format(
+            "{prefix}/{submission_date}/{doc_type}_{doc_version}".format(
                 prefix=prefix,
                 submission_date=submission_date,
                 doc_type=doc_type,

--- a/mozaggregator/cli.py
+++ b/mozaggregator/cli.py
@@ -25,12 +25,13 @@ def entry_point():
 @click.option("--credentials-prefix", type=str, required=True)
 @click.option("--num-partitions", type=int, default=10000)
 @click.option(
-    "--source", type=click.Choice(["bigquery", "moztelemetry"]), default="moztelemetry"
+    "--source", type=click.Choice(["bigquery", "moztelemetry", "avro"]), default="moztelemetry"
 )
 @click.option(
     "--project-id", envvar="PROJECT_ID", type=str, default="moz-fx-data-shared-prod"
 )
 @click.option("--dataset-id", type=str, default="payload_bytes_decoded")
+@click.option("--avro-prefix", type=str)
 def run_aggregator(
     date,
     channels,
@@ -41,6 +42,7 @@ def run_aggregator(
     source,
     project_id,
     dataset_id,
+    avro_prefix,
 ):
     spark = SparkSession.builder.getOrCreate()
 
@@ -71,6 +73,7 @@ def run_aggregator(
         source=source,
         project_id=project_id,
         dataset_id=dataset_id,
+        avro_prefix=avro_prefix,
     )
     print(f"Number of build-id aggregates: {aggregates[0].count()}")
     print(f"Number of submission date aggregates: {aggregates[1].count()}")

--- a/tests/test_fixtures.py
+++ b/tests/test_fixtures.py
@@ -11,7 +11,7 @@ def test_avro_matches_bigquery_resource(spark, bq_testing_table, avro_testing_fi
 
     for table_name, table_id in bq_testing_table:
         df = spark.read.format("avro").load(
-            avro_testing_files + "/" + table_name + "/*.avro"
+            "{}/*/{}/*.avro".format(avro_testing_files, table_name)
         )
         avro_counts = df.count()
 


### PR DESCRIPTION
[bug link](https://bugzilla.mozilla.org/show_bug.cgi?id=1594448)

```bash
bq extract \
	--destination_format=AVRO \
	'moz-fx-data-shar-nonprod-efed:payload_bytes_decoded.telemetry_telemetry__main_v4$20191101' \
	'gs://amiyaguchi-dev/avro-dump-test/20191101/main_v4/*.avro'

bq extract \
	--destination_format=AVRO \
	'moz-fx-data-shar-nonprod-efed:payload_bytes_decoded.telemetry_telemetry__saved_session_v4$20191101' \
	'gs://amiyaguchi-dev/avro-dump-test/20191101/saved_session_v4/*.avro'

NUM_WORKERS=5 bin/dataproc.sh \
	aggregator \
	--credentials-protocol s3 \
	--credentials-bucket telemetry-spark-emr-2 \
	--credentials-prefix aggregator_dev_database_envvars.json \
	--num-partitions 200 \
	--date 20191101 \
	--source avro \
	--avro-prefix gs://amiyaguchi-dev/avro-dump-test
```