### PR TITLE
Bug 1594448 - Add avro support to parquet and mobile aggregates

### DIFF
--- a/bin/dataproc.sh
+++ b/bin/dataproc.sh
@@ -59,6 +59,7 @@ function create_cluster() {
     gcloud beta dataproc clusters create ${cluster_id} \
         --image-version 1.4 \
         --enable-component-gateway \
+        --worker-machine-type=n1-standard-8 \
         --num-preemptible-workers ${NUM_WORKERS} \
         --properties ^#^spark:spark.jars=gs://spark-lib/bigquery/spark-bigquery-latest.jar#spark:spark.hadoop.fs.s3a.access.key=${AWS_ACCESS_KEY_ID}#spark:spark.hadoop.fs.s3a.secret.key=${AWS_SECRET_ACCESS_KEY}#spark:spark.jars.packages=org.apache.spark:spark-avro_2.11:2.4.4#spark:spark.python.profile=true \
         --metadata "PIP_PACKAGES=${requirements}" \

--- a/bin/dataproc.sh
+++ b/bin/dataproc.sh
@@ -16,7 +16,7 @@ function bootstrap() {
 
     # create the package artifacts
     rm -rf dist build
-    python setup.py bdist_egg
+    python3 setup.py bdist_egg
     gsutil cp "dist/${MODULE}*.egg" "gs://${bucket}/bootstrap/${MODULE}.egg"
 
     # create the initialization script and runner
@@ -56,14 +56,15 @@ function create_cluster() {
     }
     trap cleanup EXIT
 
-    gcloud dataproc clusters create ${cluster_id} \
+    gcloud beta dataproc clusters create ${cluster_id} \
         --image-version 1.4 \
         --num-preemptible-workers ${NUM_WORKERS} \
         --properties ^#^spark:spark.jars=gs://spark-lib/bigquery/spark-bigquery-latest.jar#spark:spark.hadoop.fs.s3a.access.key=${AWS_ACCESS_KEY_ID}#spark:spark.hadoop.fs.s3a.secret.key=${AWS_SECRET_ACCESS_KEY}#spark:spark.jars.packages=org.apache.spark:spark-avro_2.11:2.4.4 \
         --metadata "PIP_PACKAGES=${requirements}" \
         --initialization-actions \
             gs://${bucket}/bootstrap/install-python-dev.sh,gs://dataproc-initialization-actions/python/pip-install.sh \
-        --region=${REGION}
+        --region=${REGION} \
+        --max-idle 10m
 }
 
 
@@ -84,7 +85,7 @@ function submit() {
 function main() {
     cd "$(dirname "$0")/.."
     bucket=$(gcloud config get-value project)
-    cluster_id=test-mozaggregator
+    cluster_id="test-mozaggregator-${RANDOM}"
     bootstrap $bucket
     create_cluster $cluster_id $bucket
     submit $cluster_id $bucket "$@"

--- a/bin/dataproc.sh
+++ b/bin/dataproc.sh
@@ -60,7 +60,7 @@ function create_cluster() {
         --image-version 1.4 \
         --enable-component-gateway \
         --num-preemptible-workers ${NUM_WORKERS} \
-        --properties ^#^spark:spark.jars=gs://spark-lib/bigquery/spark-bigquery-latest.jar#spark:spark.hadoop.fs.s3a.access.key=${AWS_ACCESS_KEY_ID}#spark:spark.hadoop.fs.s3a.secret.key=${AWS_SECRET_ACCESS_KEY}#spark:spark.jars.packages=org.apache.spark:spark-avro_2.11:2.4.4 \
+        --properties ^#^spark:spark.jars=gs://spark-lib/bigquery/spark-bigquery-latest.jar#spark:spark.hadoop.fs.s3a.access.key=${AWS_ACCESS_KEY_ID}#spark:spark.hadoop.fs.s3a.secret.key=${AWS_SECRET_ACCESS_KEY}#spark:spark.jars.packages=org.apache.spark:spark-avro_2.11:2.4.4#spark:spark.python.profile=true \
         --metadata "PIP_PACKAGES=${requirements}" \
         --initialization-actions \
             gs://${bucket}/bootstrap/install-python-dev.sh,gs://dataproc-initialization-actions/python/pip-install.sh \

--- a/bin/dataproc.sh
+++ b/bin/dataproc.sh
@@ -58,6 +58,7 @@ function create_cluster() {
 
     gcloud beta dataproc clusters create ${cluster_id} \
         --image-version 1.4 \
+        --enable-component-gateway \
         --num-preemptible-workers ${NUM_WORKERS} \
         --properties ^#^spark:spark.jars=gs://spark-lib/bigquery/spark-bigquery-latest.jar#spark:spark.hadoop.fs.s3a.access.key=${AWS_ACCESS_KEY_ID}#spark:spark.hadoop.fs.s3a.secret.key=${AWS_SECRET_ACCESS_KEY}#spark:spark.jars.packages=org.apache.spark:spark-avro_2.11:2.4.4 \
         --metadata "PIP_PACKAGES=${requirements}" \

--- a/bin/export-avro.sh
+++ b/bin/export-avro.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+# A testing script for verifying the avro exports work with the existing
+# mozaggregator code. This requires `gcloud` to be configured to point at a
+# sandbox project for reading data from `payload_bytes_decoded`. There is a
+# 10 TB export limit per day, so be conservative with usage.
+
+set -eou pipefail
+
+# system agnostic way of obtaining yesterday's date, macOS' date utility doesnt provide -d
+function default_date() {
+    python3 - <<END
+from datetime import date, timedelta
+ds = f"{date.today() - timedelta(1)}"
+print(ds.replace("-",""))
+END
+}
+
+function extract_table() {
+    local table_name=$1
+    local suffix='*.avro'
+
+    # date partition must be escaped
+    local table="${SOURCE_PROJECT}:payload_bytes_decoded.telemetry_telemetry__${table_name}\$${DATE}" 
+    local output="${OUTPUT_PREFIX}/${SOURCE_PROJECT}/${DATE}/${table_name}/${suffix}"
+    
+    if gsutil -q stat "${output}"; then
+        echo "${output} already exists! skipping..."
+        return
+    fi
+
+    echo "writing ${table} to ${output}"
+    bq extract --destination_format=AVRO "${table}" "${output}"
+}
+
+function main() {
+    # moz-fx-data-shared-prod OR moz-fx-data-shar-nonprod-efed
+    SOURCE_PROJECT=${1?expected source project of BigQuery tables in first argument}
+    OUTPUT_PREFIX=${2?expected gs:// output path in second argument}
+    DATE=${3:-$(default_date)}
+
+    extract_table "main_v4"
+    extract_table "saved_session_v4"
+    extract_table "mobile_metrics_v1"
+}
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    main "$@"
+fi

--- a/mozaggregator/bigquery.py
+++ b/mozaggregator/bigquery.py
@@ -127,8 +127,8 @@ class BigQueryDataset:
         filters = []
         if channels:
             # build up a clause like "(normalized_channel = 'nightly' OR normalized_channel = 'beta')"
-            clauses = [f"normalized_channel = '{channel}'" for channel in channels]
-            joined = f"({' OR '.join(clauses)})"
+            clauses = ' OR '.join([f"normalized_channel = '{channel}'" for channel in channels])
+            joined = f"({clauses})"
             filters.append(joined)
         if filter_clause:
             filters.append(filter_clause)
@@ -136,5 +136,7 @@ class BigQueryDataset:
         df = self.spark.read.format("avro").load(
             f"{prefix}/{submission_date}/{doc_type}_{doc_version}"
         )
+        if filters:
+            df.where(" AND ".join(filters))
 
         return df.rdd.map(self._extract_payload)

--- a/mozaggregator/bigquery.py
+++ b/mozaggregator/bigquery.py
@@ -1,5 +1,5 @@
 import json
-import zlib
+import gzip
 
 from datetime import datetime, timedelta
 
@@ -56,12 +56,8 @@ class BigQueryDataset:
             |-- sample_id: long (nullable = true)
             |-- submission_timestamp: timestamp (nullable = true)
         """
-        # Add 32 to the window size to automatically decompress zlib or gzip.
-        # Because for python 2/3 compatibility, compression and decompression is
-        # done directly via zlib instead of the gzip library. Data is stored in
-        # payload_bytes_decoded as gzip.
-        # https://docs.python.org/2/library/zlib.html#zlib.decompress
-        data = json.loads(zlib.decompress(bytes(row.payload), 15 + 32))
+        # Data is stored in payload_bytes_decoded as gzip.
+        data = json.loads(gzip.decompress(row.payload).decode("utf-8"))
         # add `meta` fields for backwards compatibility
         data["meta"] = {
             "submissionDate": datetime.strftime(row.submission_timestamp, "%Y%m%d"),

--- a/mozaggregator/cli.py
+++ b/mozaggregator/cli.py
@@ -133,13 +133,14 @@ def run_parquet(
 )
 @click.option("--num-partitions", type=int, default=10000)
 @click.option(
-    "--source", type=click.Choice(["bigquery", "moztelemetry"]), default="moztelemetry"
+    "--source", type=click.Choice(["bigquery", "moztelemetry", "avro"]), default="moztelemetry"
 )
 @click.option(
     "--project-id", envvar="PROJECT_ID", type=str, default="moz-fx-data-shared-prod"
 )
 @click.option("--dataset-id", type=str, default="payload_bytes_decoded")
-def run_mobile(date, output, num_partitions, source, project_id, dataset_id):
+@click.option("--avro-prefix", type=str)
+def run_mobile(date, output, num_partitions, source, project_id, dataset_id, avro_prefix):
     spark = SparkSession.builder.getOrCreate()
 
     print(f"Running job for {date}")
@@ -150,6 +151,7 @@ def run_mobile(date, output, num_partitions, source, project_id, dataset_id):
         source=source,
         project_id=project_id,
         dataset_id=dataset_id,
+        avro_prefix=avro_prefix,
     )
     aggs = mobile.get_aggregates_dataframe(spark, agg_metrics)
     mobile.write_parquet(aggs, output)

--- a/mozaggregator/cli.py
+++ b/mozaggregator/cli.py
@@ -25,7 +25,9 @@ def entry_point():
 @click.option("--credentials-prefix", type=str, required=True)
 @click.option("--num-partitions", type=int, default=10000)
 @click.option(
-    "--source", type=click.Choice(["bigquery", "moztelemetry", "avro"]), default="moztelemetry"
+    "--source",
+    type=click.Choice(["bigquery", "moztelemetry", "avro"]),
+    default="moztelemetry",
 )
 @click.option(
     "--project-id", envvar="PROJECT_ID", type=str, default="moz-fx-data-shared-prod"
@@ -88,17 +90,22 @@ def run_aggregator(
 @click.option("--output", type=str, default="s3://telemetry-parquet/aggregates_poc/v1")
 @click.option("--num-partitions", type=int, default=10000)
 @click.option(
-    "--source", type=click.Choice(["bigquery", "moztelemetry"]), default="moztelemetry"
+    "--source",
+    type=click.Choice(["bigquery", "moztelemetry", "avro"]),
+    default="moztelemetry",
 )
 @click.option(
     "--project-id", envvar="PROJECT_ID", type=str, default="moz-fx-data-shared-prod"
 )
 @click.option("--dataset-id", type=str, default="payload_bytes_decoded")
-def run_parquet(date, channels, output, num_partitions, source, project_id, dataset_id):
+@click.option("--avro-prefix", type=str)
+def run_parquet(
+    date, channels, output, num_partitions, source, project_id, dataset_id, avro_prefix
+):
     spark = SparkSession.builder.getOrCreate()
     channels = [channel.strip() for channel in channels.split(",")]
 
-    print(("Running job for {}".format(date)))
+    print(f"Running job for {date}")
     aggregates = parquet.aggregate_metrics(
         spark.sparkContext,
         channels,
@@ -107,6 +114,7 @@ def run_parquet(date, channels, output, num_partitions, source, project_id, data
         source=source,
         project_id=project_id,
         dataset_id=dataset_id,
+        avro_prefix=avro_prefix,
     )
     print(f"Number of build-id aggregates: {aggregates[0].count()}")
     print(f"Number of submission date aggregates: {aggregates[1].count()}")

--- a/mozaggregator/mobile.py
+++ b/mozaggregator/mobile.py
@@ -159,6 +159,7 @@ def aggregate_metrics(
     source="moztelemetry",
     project_id=None,
     dataset_id=None,
+    avro_prefix=None,
     ):
     """
     Returns the build-id and submission date aggregates for a given submission date.
@@ -181,6 +182,14 @@ def aggregate_metrics(
             )
         dataset = BigQueryDataset()
         pings = dataset.load(project_id, dataset_id, "mobile_metrics", begin, doc_version="v1")
+    elif source == "avro" and avro_prefix:
+        dataset = BigQueryDataset()
+        pings = dataset.load_avro(
+            avro_prefix,
+            "mobile_metrics",
+            begin,
+            doc_version="v1",
+        )
     else:
         pings = (Dataset.from_source('telemetry')
                         .where(docType='mobile_metrics',

--- a/mozaggregator/parquet.py
+++ b/mozaggregator/parquet.py
@@ -169,7 +169,8 @@ def _map_ping_to_dimensions(ping):
 
 def aggregate_metrics(sc, channels, submission_date, main_ping_fraction=1,
                       fennec_ping_fraction=1, num_reducers=10000,
-                      source="moztelemetry", project_id=None, dataset_id=None):
+                      source="moztelemetry", project_id=None, dataset_id=None,
+                      avro_prefix=None):
     """
     Returns the build-id and submission date aggregates for a given submission date.
 
@@ -195,6 +196,22 @@ def aggregate_metrics(sc, channels, submission_date, main_ping_fraction=1,
         fennec_pings = dataset.load(
             project_id,
             dataset_id,
+            "saved_session",
+            submission_date,
+            channels,
+            "normalized_app_name = 'Fennec'"
+        )
+    elif source == "avro" and avro_prefix:
+        dataset = BigQueryDataset()
+        pings = dataset.load_avro(
+            avro_prefix,
+            "main",
+            submission_date,
+            channels,
+            "normalized_app_name <> 'Fennec'"
+        )
+        fennec_pings = dataset.load_avro(
+            avro_prefix,
             "saved_session",
             submission_date,
             channels,

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -10,3 +10,4 @@ pytest
 pytest-cov
 google-cloud-bigquery
 google-cloud-storage
+google-resumable-media

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -75,7 +75,7 @@ def bq_testing_table():
 @pytest.fixture
 def avro_testing_files(bq_testing_table):
     bq_client = bigquery.Client()
-    parent_path = os.environ["TMP_AVRO_PATH"] + "/mozaggregator_test_avro"
+    parent_path = os.path.join(os.environ["TMP_AVRO_PATH"], "mozaggregator_test_avro")
 
     for table_name, table_id in bq_testing_table:
         job = bq_client.query(

--- a/tests/test_fixtures.py
+++ b/tests/test_fixtures.py
@@ -11,11 +11,11 @@ def test_avro_matches_bigquery_resource(spark, bq_testing_table, avro_testing_fi
 
     for table_name, table_id in bq_testing_table:
         df = spark.read.format("avro").load(
-            "{}/*/{}/*.avro".format(avro_testing_files, table_name)
+            f"{avro_testing_files}/*/{table_name}/*.avro"
         )
         avro_counts = df.count()
 
-        job = bq_client.query("SELECT count(*) as row_count FROM `{}`".format(table_id))
+        job = bq_client.query(f"SELECT count(*) as row_count FROM `{table_id}`")
         bq_counts = list(job.result())[0].row_count
 
         assert avro_counts > 0

--- a/tests/test_mobile.py
+++ b/tests/test_mobile.py
@@ -8,7 +8,7 @@ from click.testing import CliRunner
 import mobile_dataset as d
 from mozaggregator.cli import run_mobile
 from mozaggregator.mobile import _aggregate_metrics, get_aggregates_dataframe
-from utils import runif_bigquery_testing_enabled
+from utils import runif_bigquery_testing_enabled, runif_avro_testing_enabled
 
 @pytest.fixture()
 def aggregates_rdd(sc):
@@ -141,6 +141,36 @@ def test_mobile_aggregation_cli_bigquery(tmp_path, spark, aggregates_rdd, bq_tes
             os.environ["PROJECT_ID"],
             "--dataset-id",
             "pytest_mozaggregator_test"
+        ],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 0
+
+    expect = get_aggregates_dataframe(spark, aggregates_rdd)
+    actual = spark.read.parquet(output)
+
+    assert expect.count() > 0 and actual.count() > 0
+    assert expect.count() == actual.count()
+
+
+@runif_avro_testing_enabled
+def test_mobile_aggregation_cli_avro(tmp_path, spark, aggregates_rdd, avro_testing_files):
+    output = str(tmp_path / "output")
+
+    result = CliRunner().invoke(
+        run_mobile,
+        [
+            "--date",
+            d.SUBMISSION_DATE_1.strftime('%Y%m%d'),
+            "--output",
+            output,
+            "--num-partitions",
+            10,
+            "--source",
+            "avro",
+            "--avro-prefix",
+            avro_testing_files,
         ],
         catch_exceptions=False,
     )

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,7 +1,7 @@
 import base64
 import json
 import os
-import zlib
+import gzip
 from datetime import datetime
 
 
@@ -22,7 +22,7 @@ def format_payload_bytes_decoded(ping):
         "submission_timestamp": datetime.strptime(
             ping["meta"]["submissionDate"], "%Y%m%d"
         ).strftime("%Y-%m-%d %H:%M:%S"),
-        "payload": base64.b64encode(zlib.compress(json.dumps(ping).encode())).decode(),
+        "payload": base64.b64encode(gzip.compress(json.dumps(ping).encode())).decode(),
     }
 
 
@@ -44,7 +44,7 @@ def format_payload_bytes_decoded_mobile(ping):
                 "app_name": ping["meta"]["appName"],
             }
         },
-        "payload": base64.b64encode(zlib.compress(json.dumps(ping).encode())).decode(),
+        "payload": base64.b64encode(gzip.compress(json.dumps(ping).encode())).decode(),
     }
 
 


### PR DESCRIPTION
[bug link](https://bugzilla.mozilla.org/show_bug.cgi?id=1594448)

This follows up with #198 to add avro support to mobile aggregates and parquet. It's much easier to verify the outputs of the parquet datasets over the aggregates postgres database. 


```
# export date from BigQuery for testing
bin/export-avro.sh moz-fx-data-shar-nonprod-efed gs://amiyaguchi-dev/avro-mozaggregator 20191101
bin/export-avro.sh moz-fx-data-shar-nonprod-efed gs://amiyaguchi-dev/avro-mozaggregator 20191101

# Run jobs on nonprod data for small test
NUM_WORKERS=5 bin/dataproc.sh \
	mobile \
	--output gs://amiyaguchi-dev/mozaggregator/mobile_test/nonprod/20191101/ \
	--num-partitions 200 \
	--date 20191101 \
	--source avro \
	--avro-prefix gs://amiyaguchi-dev/avro-mozaggregator/moz-fx-data-shar-nonprod-efed

NUM_WORKERS=5 bin/dataproc.sh \
	parquet \
	--output gs://amiyaguchi-dev/mozaggregator/parquet_test/nonprod/20191101 \
	--num-partitions 200 \
	--date 20191101 \
	--channels nightly,beta \
	--source avro \
	--avro-prefix gs://amiyaguchi-dev/avro-mozaggregator/moz-fx-data-shar-nonprod-efed

# Run jobs using full day of data for direct comparison with moztelemtry results 
NUM_WORKERS=10 bin/dataproc.sh \
	mobile \
	--output gs://amiyaguchi-dev/mozaggregator/mobile_test/prod/20191101/ \
	--num-partitions 200 \
	--date 20191101 \
	--source avro \
	--avro-prefix gs://amiyaguchi-dev/avro-mozaggregator/moz-fx-data-shared-prod

NUM_WORKERS=10 bin/dataproc.sh \
	parquet \
	--output gs://amiyaguchi-dev/mozaggregator/parquet_test/prod/20191101 \
	--num-partitions 200 \
	--date 20191101 \
	--channels nightly,beta \
	--source avro \
	--avro-prefix gs://amiyaguchi-dev/avro-mozaggregator/moz-fx-data-shared-prod
```