### PR TITLE
Partition mobile aggregates to avoid excessive load during validation

### DIFF
--- a/mozaggregator/cli.py
+++ b/mozaggregator/cli.py
@@ -142,6 +142,7 @@ def run_parquet(
 @click.option("--avro-prefix", type=str)
 def run_mobile(date, output, num_partitions, source, project_id, dataset_id, avro_prefix):
     spark = SparkSession.builder.getOrCreate()
+    spark.conf.set("spark.sql.sources.partitionOverwriteMode", "dynamic")
 
     print(f"Running job for {date}")
     agg_metrics = mobile.aggregate_metrics(

--- a/tests/test_mobile.py
+++ b/tests/test_mobile.py
@@ -144,8 +144,7 @@ def test_mobile_aggregation_cli_bigquery(tmp_path, spark, aggregates_rdd, bq_tes
         ],
         catch_exceptions=False,
     )
-
-    assert result.exit_code == 0
+    assert len({f"submission_date={d.SUBMISSION_DATE_1.strftime('%Y%m%d')}"} - set(os.listdir(output))) == 0
 
     expect = get_aggregates_dataframe(spark, aggregates_rdd)
     actual = spark.read.parquet(output)


### PR DESCRIPTION
I'd like to partition the datasets in a way that will be easy to validate and insert into BigQuery. This will otherwise create many small files. 