### PR TITLE
 Bug 1596122 - Add command to trim mozaggregator database

### DIFF
--- a/mozaggregator/cli.py
+++ b/mozaggregator/cli.py
@@ -5,7 +5,7 @@ from os import environ
 import click
 from pyspark.sql import SparkSession
 
-from mozaggregator import aggregator, db, parquet, mobile
+from mozaggregator import aggregator, db, parquet, mobile, trim_db
 
 DS_NODASH_YESTERDAY = datetime.strftime(datetime.utcnow() - timedelta(1), "%Y%m%d")
 
@@ -187,6 +187,7 @@ def run_mobile(
 entry_point.add_command(run_aggregator, "aggregator")
 entry_point.add_command(run_mobile, "mobile")
 entry_point.add_command(run_parquet, "parquet")
+entry_point.add_command(trim_db.main, "trim-database")
 
 if __name__ == "__main__":
     entry_point()

--- a/mozaggregator/mobile.py
+++ b/mozaggregator/mobile.py
@@ -194,5 +194,4 @@ def aggregate_metrics(
                         .where(docType='mobile_metrics',
                             submissionDate=lambda x: begin <= x <= end)
                         .records(sc))
-    assert pings.count() > 0
     return _aggregate_metrics(pings, num_partitions)

--- a/mozaggregator/trim_db.py
+++ b/mozaggregator/trim_db.py
@@ -1,0 +1,131 @@
+import click
+import psycopg2
+
+from typing import Set, List, Tuple
+from datetime import datetime, timedelta
+
+DS_NODASH = "%Y%m%d"
+
+
+def extract_ds_nodash(tablename):
+    return tablename.split("_")[-1]
+
+
+def retention_date_range(base: str, period: int = 365, buffer: int = 7) -> Set[str]:
+    """Create a set of dates between [base-period, base]. The date format is ds_nodash."""
+    base = datetime.strptime(base, DS_NODASH)
+    num_days = period + buffer
+    dates = set(
+        [
+            datetime.strftime(base - timedelta(period) + timedelta(x), DS_NODASH)
+            for x in range(num_days)
+        ]
+    )
+    return dates
+
+
+def create_connection(dbname, user, password, host):
+    conn_str = f"dbname={dbname} user={user} password={password} host={host}"
+    conn = psycopg2.connect(conn_str)
+    return conn
+
+
+def display_summary(action: str, table_set: Set[str], tables_to_show: int = 10):
+    tables = list(sorted(table_set, key=extract_ds_nodash))
+    print(f"To {action} {len(tables)} tables...")
+    print("-" * 40)
+    if len(tables) > tables_to_show:
+        show = tables[: tables_to_show // 2] + ["..."] + tables[-tables_to_show // 2 :]
+    else:
+        show = tables
+    print("\n".join(show))
+    print("=" * 40)
+
+
+def partition_set_by_filter(
+    full_set: Set[str], retain_suffix_set: Set[str]
+) -> Tuple[Set[str], Set[str]]:
+    retain_set = {
+        table for table in full_set if extract_ds_nodash(table) in retain_suffix_set
+    }
+    trim_set = full_set - retain_set
+    return retain_set, trim_set
+
+
+def query_submission_date(
+    cursor, retain_suffix_set: Set[str]
+) -> Tuple[Set[str], Set[str]]:
+    submission_date_query = """
+    select tablename
+    from pg_catalog.pg_tables
+    where schemaname='public' and tablename like 'submission_date%';
+    """
+    cursor.execute(submission_date_query)
+    submission_retain, submission_trim = partition_set_by_filter(
+        {row[0] for row in cursor.fetchall()}, retain_suffix_set
+    )
+    display_summary("retain", submission_retain)
+    display_summary("trim", submission_trim)
+    return submission_retain, submission_trim
+
+
+def query_build_id(cursor, retain_suffix_set: Set[str]) -> Tuple[Set[str], Set[str]]:
+    build_id_query = """
+    select tablename
+    from pg_catalog.pg_tables
+    where schemaname='public' and tablename like 'build_id%';
+    """
+    cursor.execute(build_id_query)
+    build_id_retain, build_id_trim = partition_set_by_filter(
+        {row[0] for row in cursor.fetchall()}, retain_suffix_set
+    )
+    display_summary("retain", build_id_retain)
+    display_summary("trim", build_id_trim)
+    return build_id_retain, build_id_trim
+
+
+def trim_tables(cursor, trim_set: Set[str]):
+    tables = ", ".join(trim_set)
+    query = f"drop table {tables};"
+    cursor.execute(query)
+
+
+@click.command()
+@click.option(
+    "--base-date", type=str, default=datetime.strftime(datetime.today(), DS_NODASH)
+)
+@click.option("--retention-period", type=int, default=365 * 2)
+@click.option("--dry-run/--no-dry-run", default=True)
+@click.option("--postgres-db", type=str, envvar="POSTGRES_DB", default="telemetry")
+@click.option("--postgres-user", type=str, envvar="POSTGRES_USER", default="root")
+@click.option("--postgres-pass", type=str, envvar="POSTGRES_PASS", required=True)
+@click.option("--postgres-host", type=str, envvar="POSTGRES_HOST", required=True)
+def main(
+    base_date,
+    retention_period,
+    dry_run,
+    postgres_db,
+    postgres_user,
+    postgres_pass,
+    postgres_host,
+):
+    conn = create_connection(postgres_db, postgres_user, postgres_pass, postgres_host)
+    cursor = conn.cursor()
+
+    retain_suffix_set = retention_date_range(base_date, retention_period)
+    submission_retain, submission_trim = query_submission_date(
+        cursor, retain_suffix_set
+    )
+    build_id_retain, build_id_trim = query_build_id(cursor, retain_suffix_set)
+
+    if not dry_run:
+        print("Dropping tables...")
+        trim_tables(cursor, submission_trim | build_id_trim)
+        conn.commit()
+    else:
+        print("Dry run enabled, not dropping tables...")
+    conn.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/mozaggregator/trim_db.py
+++ b/mozaggregator/trim_db.py
@@ -87,10 +87,12 @@ def query_build_id(cursor, retain_suffix_set: Set[str]) -> Tuple[Set[str], Set[s
 def trim_tables(conn, trim_set: Set[str], batch_size=100):
     cursor = conn.cursor()
     trim_list = list(trim_set)
-    num_batches = len(trim_list) // batch_size
+    num_batches = (len(trim_list) // batch_size) + 1
     for i in range(num_batches):
-        print(f"dropping {i} out of {num_batches} tables in batches of {batch_size}")
         trim_subset = trim_list[i * batch_size : (i + 1) * batch_size]
+        if not trim_subset:
+            continue
+        print(f"dropping {i+1} out of {num_batches} batches in groups of {batch_size}")
         tables = ", ".join(trim_subset)
         query = f"drop table {tables};"
         cursor.execute(query)

--- a/tests/test_trim_db.py
+++ b/tests/test_trim_db.py
@@ -95,7 +95,7 @@ def test_trim_tables(conn):
     retain, trim = trim_db.query_submission_date(cursor, set(dates[:1]))
 
     expect = full - trim
-    trim_db.trim_tables(cursor, trim)
+    trim_db.trim_tables(conn, trim)
     conn.commit()
     cursor.execute(list_tables)
     actual = {row[0] for row in cursor.fetchall()}

--- a/tests/test_trim_db.py
+++ b/tests/test_trim_db.py
@@ -1,0 +1,163 @@
+from click.testing import CliRunner
+
+import pytest
+from dataset import (
+    BUILD_ID_1,
+    BUILD_ID_2,
+    DATE_FMT,
+    SUBMISSION_DATE_1,
+    SUBMISSION_DATE_2,
+    generate_pings,
+)
+from mozaggregator import trim_db
+from mozaggregator.aggregator import _aggregate_metrics
+from mozaggregator.db import clear_db, submit_aggregates
+
+
+@pytest.fixture()
+def aggregates(sc):
+    raw_pings = list(generate_pings())
+    aggregates = _aggregate_metrics(sc.parallelize(raw_pings), num_reducers=10)
+    submit_aggregates(aggregates)
+    return aggregates
+
+
+@pytest.fixture(autouse=True)
+def clear_state():
+    clear_db()
+
+
+@pytest.fixture()
+def conn(aggregates):
+    conn = trim_db.create_connection("postgres", "postgres", "pass", "db")
+    yield conn
+    conn.close()
+
+
+def test_extract_ds_nodash():
+    cases = [
+        "build_id_beta_39_",
+        "build_id_beta_1_1",
+        "build_id_aurora_0_1000001",
+        "build_id_nightly_72_20191119",
+    ]
+    expect = ["", "1", "1000001", "20191119"]
+    actual = [trim_db.extract_ds_nodash(case) for case in cases]
+    assert actual == expect
+
+
+def test_retention_date_range():
+    base = "20191110"
+    period = 3
+    buffer = 0
+    expect = {"20191107", "20191108", "20191109"}
+    assert trim_db.retention_date_range(base, period, buffer) == expect
+
+    expect.add("20191110")
+    assert trim_db.retention_date_range(base, period, buffer + 1) == expect
+
+
+def test_query_submission_date(conn):
+    cursor = conn.cursor()
+    dates = [SUBMISSION_DATE_1.strftime(DATE_FMT), SUBMISSION_DATE_2.strftime(DATE_FMT)]
+    retain, trim = trim_db.query_submission_date(cursor, set(dates))
+    assert len(trim) == 0
+    assert len(retain) > 2  # each tablename includes the dimensions
+    assert {trim_db.extract_ds_nodash(table) for table in retain} == set(dates)
+    assert all(["submission_date" in table for table in retain])
+
+    retain, trim = trim_db.query_submission_date(cursor, set(dates[:1]))
+    assert {trim_db.extract_ds_nodash(table) for table in retain} == set(dates[:1])
+    assert {trim_db.extract_ds_nodash(table) for table in trim} == set(dates[1:])
+
+
+def test_query_build_id(conn):
+    cursor = conn.cursor()
+    builds = [BUILD_ID_1.strftime(DATE_FMT), BUILD_ID_2.strftime(DATE_FMT)]
+    retain, trim = trim_db.query_build_id(cursor, set(builds))
+    assert len(trim) == 0
+    assert len(retain) > 2  # each tablename includes the dimensions
+    assert {trim_db.extract_ds_nodash(table) for table in retain} == set(builds)
+    assert all(["build_id" in table for table in retain])
+
+    retain, trim = trim_db.query_build_id(cursor, set(builds[:1]))
+    assert {trim_db.extract_ds_nodash(table) for table in retain} == set(builds[:1])
+    assert {trim_db.extract_ds_nodash(table) for table in trim} == set(builds[1:])
+
+
+def test_trim_tables(conn):
+    cursor = conn.cursor()
+    list_tables = "select tablename from pg_catalog.pg_tables where schemaname='public'"
+    cursor.execute(list_tables)
+    full = {row[0] for row in cursor.fetchall()}
+
+    dates = [SUBMISSION_DATE_1.strftime(DATE_FMT), SUBMISSION_DATE_2.strftime(DATE_FMT)]
+    retain, trim = trim_db.query_submission_date(cursor, set(dates[:1]))
+
+    expect = full - trim
+    trim_db.trim_tables(cursor, trim)
+    conn.commit()
+    cursor.execute(list_tables)
+    actual = {row[0] for row in cursor.fetchall()}
+
+    assert expect == actual
+
+
+def test_trim_db_cli(conn):
+    cursor = conn.cursor()
+    list_tables = "select tablename from pg_catalog.pg_tables where schemaname='public'"
+    cursor.execute(list_tables)
+    before = {row[0] for row in cursor.fetchall()}
+
+    result = CliRunner().invoke(
+        trim_db.main,
+        [
+            "--base-date",
+            SUBMISSION_DATE_1.strftime(DATE_FMT),
+            "--retention-period",
+            1,
+            "--dry-run",
+            "--postgres-db",
+            "postgres",
+            "--postgres-user",
+            "postgres",
+            "--postgres-pass",
+            "pass",
+            "--postgres-host",
+            "db",
+        ],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0, result.output
+    cursor.execute(list_tables)
+    after = {row[0] for row in cursor.fetchall()}
+    assert before == after
+
+    result = CliRunner().invoke(
+        trim_db.main,
+        [
+            "--base-date",
+            SUBMISSION_DATE_1.strftime(DATE_FMT),
+            "--retention-period",
+            1,
+            "--no-dry-run",
+            "--postgres-db",
+            "postgres",
+            "--postgres-user",
+            "postgres",
+            "--postgres-pass",
+            "pass",
+            "--postgres-host",
+            "db",
+        ],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0, result.output
+
+    cursor.execute(list_tables)
+    after = {row[0] for row in cursor.fetchall()}
+
+    assert before != after
+    assert all([SUBMISSION_DATE_2.strftime(DATE_FMT) in x for x in before - after]), (
+        before - after
+    )


### PR DESCRIPTION
[bug link](https://bugzilla.mozilla.org/show_bug.cgi?id=1596122)

Running on the dev database:

```
To retain 57382 tables...
----------------------------------------
submission_date_nightly_55_20171121
submission_date_beta_46_20171121
submission_date_beta_40_20171121
submission_date_release_41_20171121
submission_date_aurora_51_20171121
...
submission_date_nightly_61_20191120
submission_date_aurora_39_20191120
submission_date_beta_44_20191120
submission_date_nightly_42_20191120
submission_date_aurora_70_20191120
========================================
To trim 42641 tables...
----------------------------------------
submission_date_aurora_41_20150601
submission_date_nightly_41_20150601
submission_date_nightly_40_20150601
submission_date_aurora_40_20150601
submission_date_aurora_40_20150603
...
submission_date_beta_57_20171120
submission_date_beta_41_20171120
submission_date_nightly_47_20171120
submission_date_release_59_20171120
submission_date_beta_1 1¤1¨1¬1°1´1¸1¼1À1Ä1È1Ì1
========================================
To retain 3374 tables...
----------------------------------------
build_id_release_57_20171121
build_id_beta_59_20171121
build_id_nightly_59_20171121
build_id_beta_58_20171121
build_id_release_59_20171121
...
build_id_aurora_71_20191119
build_id_nightly_72_20191119
build_id_nightly_68_20191119
build_id_nightly_68_20191120
build_id_nightly_72_20191120
========================================
To trim 4759 tables...
----------------------------------------
build_id_beta_39_
build_id_nightly_0_0005
build_id_beta_1_1
build_id_aurora_0_1000001
build_id_release_48_11201607
...
build_id_beta_1_git
build_id_nightly_1_git
build_id_nightly_31_git
build_id_nightly_0_xxxx
build_id_beta_1 1¤1¨1¬1°1´1¸1¼1À1Ä1È1Ì1Ð1Ô1
========================================
Dry run enabled, not dropping tables...
```