### PR TITLE
Cache aggregated datasets before insertion into database

### DIFF
--- a/mozaggregator/cli.py
+++ b/mozaggregator/cli.py
@@ -99,6 +99,8 @@ def run_aggregator(
         dataset_id=dataset_id,
         avro_prefix=avro_prefix,
     )
+    aggregates[0].cache()
+    aggregates[1].cache()
     print(f"Number of build-id aggregates: {aggregates[0].count()}")
     print(f"Number of submission date aggregates: {aggregates[1].count()}")
 


### PR DESCRIPTION
I think caching would help reduce the length of the current job in prerelease. `aggregates[1]` depends on `aggregates[0]`, both datasets are being counted, and both datasets are being mapped over for insertion into the database. It currently runs for 3.5 hours on 10x n1-standard-8. It would be useful to watch the server utilization to see where the job is being bottlenecked.

![image](https://user-images.githubusercontent.com/3304040/70274389-edac1b00-1760-11ea-9363-43df5bb6235a.png)
