### PR TITLE
Bug 1606361 - Update docker image for exporting avro data

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,14 @@ EXPOSE $PORT
 RUN apt-get update -y && \
     apt-get install -y --no-install-recommends openjdk-8-jdk
 
+# Install Cloud SDK: https://cloud.google.com/sdk/docs/quickstart-debian-ubuntu
+RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] http://packages.cloud.google.com/apt cloud-sdk main" | \
+    tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && \
+    curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | \
+    apt-key --keyring /usr/share/keyrings/cloud.google.gpg  add - && \
+    apt-get update -y && \
+    apt-get install google-cloud-sdk -y
+
 RUN apt-get update -y && \
     apt-get install -y --no-install-recommends \
         # production only libs on next line.

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -18,6 +18,14 @@ EXPOSE $PORT
 RUN apt-get update -y && \
     apt-get install -y --no-install-recommends openjdk-8-jdk
 
+# Install Cloud SDK: https://cloud.google.com/sdk/docs/quickstart-debian-ubuntu
+RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] http://packages.cloud.google.com/apt cloud-sdk main" | \
+    tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && \
+    curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | \
+    apt-key --keyring /usr/share/keyrings/cloud.google.gpg  add - && \
+    apt-get update -y && \
+    apt-get install google-cloud-sdk -y
+
 RUN apt-get update -y && \
     apt-get install -y --no-install-recommends \
         gcc awscli net-tools \

--- a/bin/README
+++ b/bin/README
@@ -1,7 +1,0 @@
-This folder contains script to execute the Docker containers.
-
-The "wait-for-it" shell script comes from https://github.com/vishnubob/wait-for-it
-
-To update this file execute the following command:
-
-    wget https://raw.githubusercontent.com/vishnubob/wait-for-it/master/wait-for-it.sh -O bin/wait-for-it.sh

--- a/bin/README.md
+++ b/bin/README.md
@@ -1,0 +1,78 @@
+# `python_mozaggregator/bin`
+
+This folder contains script to execute the Docker containers. It also contains
+scripts for managing workflows.
+
+## `wait-for-it`
+
+The "wait-for-it" shell script comes from https://github.com/vishnubob/wait-for-it
+
+To update this file execute the following command:
+
+```bash
+wget https://raw.githubusercontent.com/vishnubob/wait-for-it/master/wait-for-it.sh -O bin/wait-for-it.sh
+```
+
+## `dataproc` testing harness
+
+This script is used to spin up a DataProc cluster with the necessary jars for
+connecting to BigQuery. Clusters will automatically delete themselves after 10
+minutes of idle. Any command defined in `python_mozaggregator` can be run using
+this harness.
+
+```bash
+NUM_WORKERS=5 bin/dataproc.sh \
+    mobile \
+    --output gs://amiyaguchi-dev/mozaggregator/mobile_test/nonprod/20191101/ \
+    --num-partitions 200 \
+    --date 20191101 \
+    --source avro \
+    --avro-prefix gs://amiyaguchi-dev/avro-mozaggregator/moz-fx-data-shar-nonprod-efed
+```
+
+## `export-avro`
+
+This script can be run locally or through the docker image. You will need to
+have access to a sandbox account with access to the
+`moz-fx-data-shar-nonprod-efed` or `moz-fx-data-shared-prod` projects.
+
+```bash
+export PROJECT_ID=...
+
+bin/export-avro.sh \
+    moz-fx-data-shar-nonprod-efed \
+    ${PROJECT_ID}:avro_export \
+    gs://${PROJECT_ID}/avro-mozaggregator \
+    "main_v4" \
+    "'nightly', 'beta'" \
+    2019-12-15
+```
+
+This can also be run through the docker image:
+
+```bash
+export PROJECT_ID=...
+export GOOGLE_APPLICATION_CREDENTIALS=...
+
+docker run \
+    --entrypoint bash \
+    -v $GOOGLE_APPLICATION_CREDENTIALS:/tmp/credentials \
+    -e GOOGLE_APPLICATION_CREDENTIALS=/tmp/credentials \
+    -it mozilla/python_mozaggregator:latest \
+        gcloud auth activate-service-account --key-file /tmp/credentials && \
+        bin/export-avro.sh \
+            moz-fx-data-shar-nonprod-efed \
+            ${PROJECT_ID}:avro_export \
+            gs://${PROJECT_ID}/avro-mozaggregator \
+            "main_v4" \
+            "'nightly', 'beta'" \
+            2019-12-15
+```
+
+The production settings for pre-release aggregates are as follows:
+
+```bash
+"main_v4"              "'nightly', 'beta'"
+"saved_session_v4"     "'nightly', 'beta'"
+"mobile_metrics_v1"    ""
+```

--- a/bin/export-avro.sh
+++ b/bin/export-avro.sh
@@ -56,19 +56,15 @@ function extract_table() {
 
 function main() {
     # moz-fx-data-shared-prod OR moz-fx-data-shar-nonprod-efed
-    SOURCE_PROJECT=${1?expected source project of BigQuery tables in first argument}
-    DESTINATION_DATASET=${2?expect destination dataset of form project_id:dataset}
-    OUTPUT_PREFIX=${3?expected gs:// output path in second argument}
-    DATE=${4:-$(default_date)}
+    SOURCE_PROJECT=${1?expected source project of BigQuery tables in 1st argument}
+    DESTINATION_DATASET=${2?expected destination dataset of form project_id:dataset}
+    OUTPUT_PREFIX=${3?expected gs:// output path in 3rd argument}
+    TABLE_NAME=${4?expected table name in 4th argument}
+    CHANNELS=${5?expected channels in the 5th argument}
+    DATE=${6:-$(default_date)}
 
-    # NOTE: channels are hardcoded...
-    query_to_destination "main_v4"              "'nightly', 'beta'"
-    query_to_destination "saved_session_v4"     "'nightly', 'beta'"
-    query_to_destination "mobile_metrics_v1"    ""
-
-    extract_table "main_v4"
-    extract_table "saved_session_v4"
-    extract_table "mobile_metrics_v1"
+    query_to_destination "${TABLE_NAME}" "${CHANNELS}"
+    extract_table "${TABLE_NAME}"
 }
 
 if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then


### PR DESCRIPTION
[bug link](https://bugzilla.mozilla.org/show_bug.cgi?id=1606361)

This is tested using the following commands:

```bash
export GOOGLE_APPLICATION_CREDENTIALS=/path/to/service-account.json

docker build -t mozagg:latest .

function run_export() {
    local table=$1
    local channels=$2
    local date=$3
    docker run \
        --entrypoint bash \
        -v $GOOGLE_APPLICATION_CREDENTIALS:/tmp/credentials \
        -e GOOGLE_APPLICATION_CREDENTIALS=/tmp/credentials \
        -it mozagg:latest \
        gcloud auth activate-service-account --key-file /tmp/credentials && \
        bin/export-avro.sh \
        moz-fx-data-shar-nonprod-efed \
        amiyaguchi-dev:avro_export \
        gs://amiyaguchi-dev/avro-mozaggregator \
        "$table" \
        "$channels" \
        "$date"
}

# run_export main_v4 "'nightly', 'beta'" 2019-12-29
run_export saved_session_v4 "'nightly', 'beta'" 2019-12-29
run_export mobile_metrics_v1 "" 2019-12-29

NUM_WORKERS=3 bin/dataproc.sh \
	mobile \
	--output gs://amiyaguchi-dev/mozaggregator/mobile_test/nonprod/20191229/ \
	--num-partitions 200 \
	--date 20191229 \
	--source avro \
	--avro-prefix gs://amiyaguchi-dev/avro-mozaggregator/moz-fx-data-shar-nonprod-efed
```

results in

```bash
gsutil ls -r gs://amiyaguchi-dev/mozaggregator/mobile_test/nonprod/20191229
gs://amiyaguchi-dev/mozaggregator/mobile_test/nonprod/20191229/:
gs://amiyaguchi-dev/mozaggregator/mobile_test/nonprod/20191229/
gs://amiyaguchi-dev/mozaggregator/mobile_test/nonprod/20191229/_SUCCESS

gs://amiyaguchi-dev/mozaggregator/mobile_test/nonprod/20191229/submission_date=20191229/:
gs://amiyaguchi-dev/mozaggregator/mobile_test/nonprod/20191229/submission_date=20191229/
gs://amiyaguchi-dev/mozaggregator/mobile_test/nonprod/20191229/submission_date=20191229/part-00000-9d7bd21e-c5f7-4c10-b0bb-69ad818b90e6.c000.snappy.parquet
```