### PR TITLE
Add drop query for june 2021

### DIFF
--- a/queries/drop_june_2021.sql
+++ b/queries/drop_june_2021.sql
@@ -1,0 +1,78 @@
+CREATE OR REPLACE FUNCTION try_cast_int(p_in TEXT, p_default INT default null)
+RETURNS INT
+LANGUAGE plpgsql;
+AS $$
+BEGIN
+  BEGIN
+    RETURN $1::INT;
+  EXCEPTION 
+    WHEN others THEN
+       RETURN p_default;
+  END;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION reverse(TEXT)
+RETURNS TEXT
+AS $$
+SELECT array_to_string(ARRAY(
+  SELECT SUBSTRING($1, s.i,1) FROM generate_series(LENGTH($1), 1, -1) AS s(i)
+  ), '');
+$$ LANGUAGE SQL IMMUTABLE STRICT;
+
+CREATE OR REPLACE FUNCTION drop_tables_before_date(IN _schema TEXT, IN _min_date INT) 
+RETURNS void 
+LANGUAGE plpgsql
+AS
+$$
+DECLARE
+    row record;
+BEGIN
+    FOR row IN 
+        SELECT
+            table_schema,
+            table_name
+        FROM
+            information_schema.tables
+        WHERE
+            table_type = 'BASE TABLE'
+        AND
+            table_schema = _schema
+        AND
+            try_cast_int(reverse(split_part(reverse(table_name), '_', 1)), _min_date-1) < _min_date
+    LOOP
+        EXECUTE 'DROP TABLE ' || quote_ident(row.table_schema) || '.' || quote_ident(row.table_name);
+        RAISE INFO 'Dropped table: %', quote_ident(row.table_schema) || '.' || quote_ident(row.table_name);
+    END LOOP;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION get_tables_to_drop(IN _schema TEXT, IN _min_date INT) 
+RETURNS table ( name TEXT ) 
+LANGUAGE plpgsql
+AS
+$$
+DECLARE
+    row record;
+BEGIN
+    FOR row IN 
+        SELECT
+            table_schema,
+            table_name
+        FROM
+            information_schema.tables
+        WHERE
+            table_type = 'BASE TABLE'
+        AND
+            table_schema = _schema
+        AND
+            try_cast_int(reverse(split_part(reverse(table_name), '_', 1)), _min_date-1) < _min_date
+    LOOP
+        return quote_ident(row.table_schema) || '.' || quote_ident(row.table_name);
+    END LOOP;
+END;
+$$;
+
+SELECT * FROM get_tables_to_drop('public', '20190601');
+
+SELECT drop_tables_before_date('public', '20190601');


### PR DESCRIPTION
@haroldwoo, can you run just the `SELECT * FROM get_tables_to_drop('public', '20190601');` and let me know what the output is?