### PR TITLE
Minimum change to use PBD main v5

### DIFF
--- a/bin/export-avro.sh
+++ b/bin/export-avro.sh
@@ -20,6 +20,9 @@ function query_to_destination() {
     local table_name=$1
     local document_type=$(echo "$table_name" | cut -d_ -f1)
     local document_version=$(echo "$table_name" | cut -d_ -f2 | cut -c2-)
+    if [[ "$document_type" == "main" ]] ; then
+      document_version="5"
+    fi
     local channels=$2
 
     local table="${SOURCE_PROJECT}.payload_bytes_decoded.telemetry"

--- a/mozaggregator/bigquery.py
+++ b/mozaggregator/bigquery.py
@@ -90,6 +90,8 @@ class BigQueryDataset:
         )
         filters = [date_clause]
         doc_version_suffix = doc_version[-1]
+        if doc_type == "main":
+            doc_version_suffix = "5"
         doc_clause = f"metadata.document_type = '{doc_type}' AND metadata.document_version = '{doc_version_suffix}'"
         filters.append(doc_clause)
 


### PR DESCRIPTION
We're planning to deprecate main v4 soon (as early as next week) and PBD entirely (by EOY). For cost reasons it makes sense to prioritize the former since we're doubling Pub/Sub cost in the current state. In order to disable uploading to main v4 we need this job to read v5 instead. I'm assuming that v5 has the relevant columns for mozaggregator to do its work; this should be verified by a reviewer. My hypothesis here is that the following change is the minimum set required to use v5 instead of v4. It doesn't change all downstream identifiers e.g. v4 in avro exports but given the pending deprecation I'm trying to change the least number of things.

This would need to be manually uploaded to GCR as `pbd_fix_2` was. I think we should probably not merge this into the target branch and instead push this as a separate tag and update Airflow to point to this branch but I'm filing this as a PR to get review. 